### PR TITLE
Fixes execution order for line number ruler

### DIFF
--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -136,6 +136,9 @@ public class Gui {
         m_selectionHighlightPainter = new SelectionHighlightPainter();
         this.editor = new PanelEditor(this);
         JScrollPane sourceScroller = new JScrollPane(this.editor);
+        this.editor.setContentType("text/java");
+        DefaultSyntaxKit kit = (DefaultSyntaxKit) this.editor.getEditorKit();
+        kit.toggleComponent(this.editor, "de.sciss.syntaxpane.components.TokenMarker");
 
         // init editor popup menu
         this.popupMenu = new PopupMenuBar(this);

--- a/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
+++ b/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
@@ -10,7 +10,6 @@ import javax.swing.JEditorPane;
 
 import cuchaz.enigma.gui.BrowserCaret;
 import cuchaz.enigma.gui.Gui;
-import de.sciss.syntaxpane.DefaultSyntaxKit;
 
 public class PanelEditor extends JEditorPane {
     private final Gui gui;
@@ -21,7 +20,6 @@ public class PanelEditor extends JEditorPane {
         this.setEditable(false);
         this.setSelectionColor(new Color(31, 46, 90));
         this.setCaret(new BrowserCaret());
-        this.setContentType("text/java");
         this.addCaretListener(event -> gui.onCaretMove(event.getDot()));
         final PanelEditor self = this;
         this.addMouseListener(new MouseAdapter()
@@ -71,8 +69,5 @@ public class PanelEditor extends JEditorPane {
                 }
             }
         });
-
-        DefaultSyntaxKit kit = (DefaultSyntaxKit) this.getEditorKit();
-        kit.toggleComponent(this, "de.sciss.syntaxpane.components.TokenMarker");
     }
 }


### PR DESCRIPTION
Restores rendering the line numbers ruler in the editor, related to issue #39.

![enigma](https://cloud.githubusercontent.com/assets/5352172/19478294/b3f5b1f0-954a-11e6-9e15-c8a69f87a3c4.png)

