### PR TITLE
Add support for custom themes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     compile 'com.google.guava:guava:21.+'
     compile 'org.javassist:javassist:3.21.0-GA'
     compile 'org.bitbucket.mstrobel:procyon-compilertools:0.5.33.8-enigma'
+    compile 'commons-io:commons-io:2.5'
+    compile 'com.google.code.gson:gson:2.8.1'
+
 
     application 'de.sciss:syntaxpane:1.1.+'
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     compile 'com.google.guava:guava:21.+'
     compile 'org.javassist:javassist:3.21.0-GA'
     compile 'org.bitbucket.mstrobel:procyon-compilertools:0.5.33.8-enigma'
-    compile 'commons-io:commons-io:2.5'
     compile 'com.google.code.gson:gson:2.8.1'
 
 

--- a/src/main/java/cuchaz/enigma/Main.java
+++ b/src/main/java/cuchaz/enigma/Main.java
@@ -11,6 +11,7 @@
 
 package cuchaz.enigma;
 
+import cuchaz.enigma.config.Config;
 import cuchaz.enigma.gui.Gui;
 
 import javax.swing.*;
@@ -20,7 +21,8 @@ import java.util.jar.JarFile;
 public class Main {
 
 	public static void main(String[] args) throws Exception {
-		if (System.getProperty("enigma.useSystemLookAndFeel", "true").equals("true"))
+		Config.loadConfig();
+		if (Config.INSTANCE.useSystemLAF)
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 		Gui gui = new Gui();
 

--- a/src/main/java/cuchaz/enigma/config/Config.java
+++ b/src/main/java/cuchaz/enigma/config/Config.java
@@ -1,0 +1,19 @@
+package cuchaz.enigma.config;
+
+/**
+ * Created by Mark on 04/06/2017.
+ */
+public class Config {
+
+    public static Config INSTANCE = new Config();
+
+    public int obfuscatedColor = 0xFFDCDC;
+    public int obfuscatedColorOutline = 0xA05050;
+
+    public int deobfuscatedColor = 0xDCFFDC;
+    public int deobfuscatedColorOutline = 0x50A050;
+
+    public int editorBackground = 0xFFFFFF;
+
+
+}

--- a/src/main/java/cuchaz/enigma/config/Config.java
+++ b/src/main/java/cuchaz/enigma/config/Config.java
@@ -16,12 +16,28 @@ public class Config {
     public static Config INSTANCE = new Config();
 
     public Integer obfuscatedColor = 0xFFDCDC;
+    public float obfuscatedHiglightAlpha = 1.0F;
     public Integer obfuscatedColorOutline = 0xA05050;
+    public float obfuscatedOutlineAlpha = 1.0F;
 
     public Integer deobfuscatedColor = 0xDCFFDC;
+    public float deobfuscatedHiglightAlpha = 1.0F;
     public Integer deobfuscatedColorOutline = 0x50A050;
+    public float deobfuscatedOutlineAlpha = 1.0F;
 
+    public Integer otherColorOutline = 0xB4B4B4;
+    public float otherOutlineAlpha = 1.0F;
+
+    //Defaults found here: https://github.com/Sciss/SyntaxPane/blob/122da367ff7a5d31627a70c62a48a9f0f4f85a0a/src/main/resources/de/sciss/syntaxpane/defaultsyntaxkit/config.properties#L139
     public Integer editorBackground = 0xFFFFFF;
+    public Integer highlightColor = 0x3333EE;
+    public Integer stringColor = 0xCC6600;
+    public Integer numberColor = 0x999933;
+    public Integer operatorColor = 0x000000;
+    public Integer delimiterColor = 0x000000;
+    public Integer typeColor = 0x000000;
+    public Integer identifierColor = 0x000000;
+    public Integer defaultTextColor = 0x000000;
 
     public boolean useSystemLAF = true;
 

--- a/src/main/java/cuchaz/enigma/config/Config.java
+++ b/src/main/java/cuchaz/enigma/config/Config.java
@@ -1,5 +1,13 @@
 package cuchaz.enigma.config;
 
+import com.google.gson.*;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+
 /**
  * Created by Mark on 04/06/2017.
  */
@@ -7,13 +15,35 @@ public class Config {
 
     public static Config INSTANCE = new Config();
 
-    public int obfuscatedColor = 0xFFDCDC;
-    public int obfuscatedColorOutline = 0xA05050;
+    public Integer obfuscatedColor = 0xFFDCDC;
+    public Integer obfuscatedColorOutline = 0xA05050;
 
-    public int deobfuscatedColor = 0xDCFFDC;
-    public int deobfuscatedColorOutline = 0x50A050;
+    public Integer deobfuscatedColor = 0xDCFFDC;
+    public Integer deobfuscatedColorOutline = 0x50A050;
 
-    public int editorBackground = 0xFFFFFF;
+    public Integer editorBackground = 0xFFFFFF;
 
+    public boolean useSystemLAF = true;
+
+    public static void loadConfig() throws IOException {
+        Gson gson = new GsonBuilder().registerTypeAdapter(Integer.class, new IntSerializer()).registerTypeAdapter(Integer.class, new IntDeserializer()).setPrettyPrinting().create();
+        File configFile = new File(".engimaConfig.json");
+        if (configFile.exists()) {
+            INSTANCE = gson.fromJson(FileUtils.readFileToString(configFile, Charset.defaultCharset()), Config.class);
+        }
+        FileUtils.writeStringToFile(configFile, gson.toJson(INSTANCE), Charset.defaultCharset());
+    }
+
+    private static class IntSerializer implements JsonSerializer<Integer> {
+        public JsonElement serialize(Integer src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive("#" + Integer.toHexString(src).toUpperCase());
+        }
+    }
+
+    private static class IntDeserializer implements JsonDeserializer<Integer> {
+        public Integer deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+            return (int) Long.parseLong(json.getAsString().replace("#", ""), 16);
+        }
+    }
 
 }

--- a/src/main/java/cuchaz/enigma/config/Config.java
+++ b/src/main/java/cuchaz/enigma/config/Config.java
@@ -43,7 +43,9 @@ public class Config {
 
     public static void loadConfig() throws IOException {
         Gson gson = new GsonBuilder().registerTypeAdapter(Integer.class, new IntSerializer()).registerTypeAdapter(Integer.class, new IntDeserializer()).setPrettyPrinting().create();
-        File configFile = new File(".engimaConfig.json");
+        File dirHome = new File(System.getProperty("user.home"));
+        File engimaDir = new File(dirHome, ".enigma");
+        File configFile = new File(engimaDir, "config.json");
         if (configFile.exists()) {
             INSTANCE = gson.fromJson(FileUtils.readFileToString(configFile, Charset.defaultCharset()), Config.class);
         }

--- a/src/main/java/cuchaz/enigma/config/Config.java
+++ b/src/main/java/cuchaz/enigma/config/Config.java
@@ -1,7 +1,7 @@
 package cuchaz.enigma.config;
 
+import com.google.common.io.Files;
 import com.google.gson.*;
-import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,11 +45,16 @@ public class Config {
         Gson gson = new GsonBuilder().registerTypeAdapter(Integer.class, new IntSerializer()).registerTypeAdapter(Integer.class, new IntDeserializer()).setPrettyPrinting().create();
         File dirHome = new File(System.getProperty("user.home"));
         File engimaDir = new File(dirHome, ".enigma");
+        if(!engimaDir.exists()){
+            engimaDir.mkdirs();
+        }
         File configFile = new File(engimaDir, "config.json");
         if (configFile.exists()) {
-            INSTANCE = gson.fromJson(FileUtils.readFileToString(configFile, Charset.defaultCharset()), Config.class);
+            INSTANCE = gson.fromJson(Files.toString(configFile, Charset.defaultCharset()), Config.class);
+        } else {
+            Files.touch(configFile);
         }
-        FileUtils.writeStringToFile(configFile, gson.toJson(INSTANCE), Charset.defaultCharset());
+        Files.write(gson.toJson(INSTANCE), configFile, Charset.defaultCharset());
     }
 
     private static class IntSerializer implements JsonSerializer<Integer> {

--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -15,6 +15,7 @@ import com.google.common.collect.Lists;
 import cuchaz.enigma.Constants;
 import cuchaz.enigma.ExceptionIgnorer;
 import cuchaz.enigma.analysis.*;
+import cuchaz.enigma.config.Config;
 import cuchaz.enigma.gui.dialog.CrashDialog;
 import cuchaz.enigma.gui.elements.MenuBar;
 import cuchaz.enigma.gui.elements.PopupMenuBar;
@@ -134,6 +135,7 @@ public class Gui {
 		this.editor = new PanelEditor(this);
 		JScrollPane sourceScroller = new JScrollPane(this.editor);
 		this.editor.setContentType("text/java");
+		this.editor.setBackground(new Color(Config.INSTANCE.editorBackground));
 		DefaultSyntaxKit kit = (DefaultSyntaxKit) this.editor.getEditorKit();
 		kit.toggleComponent(this.editor, "de.sciss.syntaxpane.components.TokenMarker");
 

--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -48,10 +48,8 @@ import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
 import java.util.List;
-import java.util.Vector;
 import java.util.function.Function;
 
 public class Gui {
@@ -128,13 +126,14 @@ public class Gui {
 
 		// init editor
 		DefaultSyntaxKit.initKit();
+		DefaultSyntaxKit.registerContentType("text/minecraft", MinecraftSyntaxKit.class.getName());
 		obfuscatedHighlightPainter = new ObfuscatedHighlightPainter();
 		deobfuscatedHighlightPainter = new DeobfuscatedHighlightPainter();
 		otherHighlightPainter = new OtherHighlightPainter();
 		selectionHighlightPainter = new SelectionHighlightPainter();
 		this.editor = new PanelEditor(this);
 		JScrollPane sourceScroller = new JScrollPane(this.editor);
-		this.editor.setContentType("text/java");
+		this.editor.setContentType("text/minecraft");
 		this.editor.setBackground(new Color(Config.INSTANCE.editorBackground));
 		DefaultSyntaxKit kit = (DefaultSyntaxKit) this.editor.getEditorKit();
 		kit.toggleComponent(this.editor, "de.sciss.syntaxpane.components.TokenMarker");

--- a/src/main/java/cuchaz/enigma/gui/MinecraftSyntaxKit.java
+++ b/src/main/java/cuchaz/enigma/gui/MinecraftSyntaxKit.java
@@ -1,0 +1,37 @@
+package cuchaz.enigma.gui;
+
+import cuchaz.enigma.config.Config;
+import de.sciss.syntaxpane.syntaxkits.JavaSyntaxKit;
+import de.sciss.syntaxpane.util.Configuration;
+
+/**
+ * Created by Mark on 04/06/2017.
+ */
+public class MinecraftSyntaxKit extends JavaSyntaxKit {
+
+    public Configuration configuration = null;
+
+    @Override
+    public Configuration getConfig() {
+        if(configuration == null){
+            initConfig(super.getConfig(JavaSyntaxKit.class));
+        }
+        return configuration;
+    }
+
+    public void initConfig(Configuration baseConfig){
+        configuration = baseConfig;
+        //See de.sciss.syntaxpane.TokenType
+        configuration.put("Style.KEYWORD", Config.INSTANCE.highlightColor + ", 0");
+        configuration.put("Style.KEYWORD2", Config.INSTANCE.highlightColor + ", 3");
+        configuration.put("Style.STRING", Config.INSTANCE.stringColor + ", 0");
+        configuration.put("Style.STRING2", Config.INSTANCE.stringColor + ", 1");
+        configuration.put("Style.NUMBER", Config.INSTANCE.numberColor + ", 1");
+        configuration.put("Style.OPERATOR", Config.INSTANCE.operatorColor + ", 0");
+        configuration.put("Style.DELIMITER", Config.INSTANCE.delimiterColor + ", 1");
+        configuration.put("Style.TYPE", Config.INSTANCE.typeColor + ", 2");
+        configuration.put("Style.TYPE2", Config.INSTANCE.typeColor + ", 1");
+        configuration.put("Style.IDENTIFIER", Config.INSTANCE.identifierColor + ", 0");
+        configuration.put("Style.DEFAULT", Config.INSTANCE.defaultTextColor + ", 0");
+    }
+}

--- a/src/main/java/cuchaz/enigma/gui/MinecraftSyntaxKit.java
+++ b/src/main/java/cuchaz/enigma/gui/MinecraftSyntaxKit.java
@@ -33,5 +33,6 @@ public class MinecraftSyntaxKit extends JavaSyntaxKit {
         configuration.put("Style.TYPE2", Config.INSTANCE.typeColor + ", 1");
         configuration.put("Style.IDENTIFIER", Config.INSTANCE.identifierColor + ", 0");
         configuration.put("Style.DEFAULT", Config.INSTANCE.defaultTextColor + ", 0");
+        configuration.put("RightMarginColumn", "999"); //No need to have a right margin, if someone wants it add a config
     }
 }

--- a/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
+++ b/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
@@ -58,4 +58,9 @@ public abstract class BoxHighlightPainter implements Highlighter.HighlightPainte
 		g.setColor(this.borderColor);
 		g.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, 4, 4);
 	}
+
+	protected static Color getColor(int rgb, float alpha){
+		Color baseColor = new Color(rgb);
+		return new Color(baseColor.getRed(), baseColor.getGreen(), baseColor.getBlue(), (int)(255 * alpha));
+	}
 }

--- a/src/main/java/cuchaz/enigma/gui/highlight/DeobfuscatedHighlightPainter.java
+++ b/src/main/java/cuchaz/enigma/gui/highlight/DeobfuscatedHighlightPainter.java
@@ -13,11 +13,9 @@ package cuchaz.enigma.gui.highlight;
 
 import cuchaz.enigma.config.Config;
 
-import java.awt.*;
-
 public class DeobfuscatedHighlightPainter extends BoxHighlightPainter {
 
 	public DeobfuscatedHighlightPainter() {
-		super(new Color(Config.INSTANCE.deobfuscatedColor), new Color(Config.INSTANCE.deobfuscatedColorOutline));
+		super(getColor(Config.INSTANCE.deobfuscatedColor, Config.INSTANCE.deobfuscatedHiglightAlpha), getColor(Config.INSTANCE.deobfuscatedColorOutline, Config.INSTANCE.deobfuscatedOutlineAlpha));
 	}
 }

--- a/src/main/java/cuchaz/enigma/gui/highlight/DeobfuscatedHighlightPainter.java
+++ b/src/main/java/cuchaz/enigma/gui/highlight/DeobfuscatedHighlightPainter.java
@@ -11,11 +11,13 @@
 
 package cuchaz.enigma.gui.highlight;
 
+import cuchaz.enigma.config.Config;
+
 import java.awt.*;
 
 public class DeobfuscatedHighlightPainter extends BoxHighlightPainter {
 
 	public DeobfuscatedHighlightPainter() {
-		super(new Color(220, 255, 220), new Color(80, 160, 80));
+		super(new Color(Config.INSTANCE.deobfuscatedColor), new Color(Config.INSTANCE.deobfuscatedColorOutline));
 	}
 }

--- a/src/main/java/cuchaz/enigma/gui/highlight/ObfuscatedHighlightPainter.java
+++ b/src/main/java/cuchaz/enigma/gui/highlight/ObfuscatedHighlightPainter.java
@@ -18,6 +18,6 @@ import java.awt.*;
 public class ObfuscatedHighlightPainter extends BoxHighlightPainter {
 
 	public ObfuscatedHighlightPainter() {
-		super(new Color(Config.INSTANCE.obfuscatedColor), new Color(Config.INSTANCE.obfuscatedColorOutline));
+		super(getColor(Config.INSTANCE.obfuscatedColor, Config.INSTANCE.obfuscatedHiglightAlpha), getColor(Config.INSTANCE.obfuscatedColorOutline, Config.INSTANCE.obfuscatedOutlineAlpha));
 	}
 }

--- a/src/main/java/cuchaz/enigma/gui/highlight/ObfuscatedHighlightPainter.java
+++ b/src/main/java/cuchaz/enigma/gui/highlight/ObfuscatedHighlightPainter.java
@@ -11,11 +11,13 @@
 
 package cuchaz.enigma.gui.highlight;
 
+import cuchaz.enigma.config.Config;
+
 import java.awt.*;
 
 public class ObfuscatedHighlightPainter extends BoxHighlightPainter {
 
 	public ObfuscatedHighlightPainter() {
-		super(new Color(255, 220, 220), new Color(160, 80, 80));
+		super(new Color(Config.INSTANCE.obfuscatedColor), new Color(Config.INSTANCE.obfuscatedColorOutline));
 	}
 }

--- a/src/main/java/cuchaz/enigma/gui/highlight/OtherHighlightPainter.java
+++ b/src/main/java/cuchaz/enigma/gui/highlight/OtherHighlightPainter.java
@@ -11,11 +11,11 @@
 
 package cuchaz.enigma.gui.highlight;
 
-import java.awt.*;
+import cuchaz.enigma.config.Config;
 
 public class OtherHighlightPainter extends BoxHighlightPainter {
 
 	public OtherHighlightPainter() {
-		super(null, new Color(180, 180, 180));
+		super(null, getColor(Config.INSTANCE.otherColorOutline, Config.INSTANCE.otherOutlineAlpha));
 	}
 }


### PR DESCRIPTION
![java_2017-06-04_14-40-41](https://cloud.githubusercontent.com/assets/4324090/26762092/d3f11376-4933-11e7-91c9-7852e77f7076.png)

Allows for things like that ^
The default settings are as before

Questions before merge: 
Where should the config be located? Currently in the working dir.
Should I add some presets like the one pictured above?

Things to do later:
Change the theme of the other gui components to fit in with the style.
