### PR TITLE
Tweak variable name generation

### DIFF
--- a/src/main/java/cuchaz/enigma/mapping/NameValidator.java
+++ b/src/main/java/cuchaz/enigma/mapping/NameValidator.java
@@ -66,4 +66,8 @@ public class NameValidator {
 	public static String validateArgumentName(String name) {
 		return validateFieldName(name);
 	}
+
+	public static boolean isReserved(String name) {
+		return ReservedWords.contains(name);
+	}
 }

--- a/src/main/java/cuchaz/enigma/mapping/TypeDescriptor.java
+++ b/src/main/java/cuchaz/enigma/mapping/TypeDescriptor.java
@@ -223,14 +223,14 @@ public class TypeDescriptor {
 	}
 
 	public enum Primitive {
-		Byte('B'),
-		Character('C'),
-		Short('S'),
-		Integer('I'),
-		Long('J'),
-		Float('F'),
-		Double('D'),
-		Boolean('Z');
+		BYTE('B'),
+		CHARACTER('C'),
+		SHORT('S'),
+		INTEGER('I'),
+		LONG('J'),
+		FLOAT('F'),
+		DOUBLE('D'),
+		BOOLEAN('Z');
 
 		private static final Map<Character, Primitive> lookup;
 

--- a/src/main/java/cuchaz/enigma/mapping/entry/MethodDefEntry.java
+++ b/src/main/java/cuchaz/enigma/mapping/entry/MethodDefEntry.java
@@ -42,4 +42,20 @@ public class MethodDefEntry extends MethodEntry implements DefEntry {
 	public MethodDefEntry updateOwnership(ClassEntry classEntry) {
 		return new MethodDefEntry(new ClassEntry(classEntry.getName()), name, descriptor, signature, access);
 	}
+
+	public int getArgumentIndex(ClassDefEntry ownerEntry, int localVariableIndex) {
+		int argumentIndex = localVariableIndex;
+
+		// Enum constructors have an implicit "name" and "ordinal" parameter as well as "this"
+		if (ownerEntry.getAccess().isEnum() && getName().startsWith("<")) {
+			argumentIndex -= 2;
+		}
+
+		// If we're not static, "this" is bound to index 0
+		if (!getAccess().isStatic()) {
+			argumentIndex -= 1;
+		}
+
+		return argumentIndex;
+	}
 }

--- a/src/test/java/cuchaz/enigma/TestTypeDescriptor.java
+++ b/src/test/java/cuchaz/enigma/TestTypeDescriptor.java
@@ -51,13 +51,13 @@ public class TestTypeDescriptor {
 
 	@Test
 	public void getPrimitive() {
-		assertThat(new TypeDescriptor("Z").getPrimitive(), is(TypeDescriptor.Primitive.Boolean));
-		assertThat(new TypeDescriptor("B").getPrimitive(), is(TypeDescriptor.Primitive.Byte));
-		assertThat(new TypeDescriptor("C").getPrimitive(), is(TypeDescriptor.Primitive.Character));
-		assertThat(new TypeDescriptor("I").getPrimitive(), is(TypeDescriptor.Primitive.Integer));
-		assertThat(new TypeDescriptor("J").getPrimitive(), is(TypeDescriptor.Primitive.Long));
-		assertThat(new TypeDescriptor("F").getPrimitive(), is(TypeDescriptor.Primitive.Float));
-		assertThat(new TypeDescriptor("D").getPrimitive(), is(TypeDescriptor.Primitive.Double));
+		assertThat(new TypeDescriptor("Z").getPrimitive(), is(TypeDescriptor.Primitive.BOOLEAN));
+		assertThat(new TypeDescriptor("B").getPrimitive(), is(TypeDescriptor.Primitive.BYTE));
+		assertThat(new TypeDescriptor("C").getPrimitive(), is(TypeDescriptor.Primitive.CHARACTER));
+		assertThat(new TypeDescriptor("I").getPrimitive(), is(TypeDescriptor.Primitive.INTEGER));
+		assertThat(new TypeDescriptor("J").getPrimitive(), is(TypeDescriptor.Primitive.LONG));
+		assertThat(new TypeDescriptor("F").getPrimitive(), is(TypeDescriptor.Primitive.FLOAT));
+		assertThat(new TypeDescriptor("D").getPrimitive(), is(TypeDescriptor.Primitive.DOUBLE));
 	}
 
 	@Test


### PR DESCRIPTION
This PR tweaks argument and local variable name generation to be more easily readable. This is achieved with a few changes:
 - The redundant `a` and `v` prefixes have been removed
 - Argument index suffixes are only added if the argument type is not unique

Additionally, this fixes an issue where some arguments would be considered local variables due to an incorrect local variable -> argument index offset.

This result be seen here:
![Result](https://i.imgur.com/CxytE9N.png)