### PR TITLE
Reset dirty inner classes too when resetDirty is called

### DIFF
--- a/src/main/java/cuchaz/enigma/mapping/ClassMapping.java
+++ b/src/main/java/cuchaz/enigma/mapping/ClassMapping.java
@@ -540,6 +540,9 @@ public class ClassMapping implements Comparable<ClassMapping> {
 
 	public void resetDirty() {
 		this.isDirty = false;
+		for (ClassMapping c : this.innerClasses()) {
+			c.resetDirty();
+		}
 	}
 
 	public void markDirty() {


### PR DESCRIPTION
Currently `savePreviousState` doesn't reset the `isDirty` boolean for inner classes, causing mappings for classes containing inner classes to be saved every time `saveEnigmaMappings` is called despite there being no changes.