### PR TITLE
Standardize mapping line endings to LF

### DIFF
--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
@@ -21,6 +21,7 @@ import cuchaz.enigma.translation.mapping.VoidEntryResolver;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
 import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
 import cuchaz.enigma.translation.representation.entry.*;
+import cuchaz.enigma.utils.LFPrintWriter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -45,7 +46,7 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 			progress.init(classes.size(), "Writing classes");
 
 			int steps = 0;
-			try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(path))) {
+			try (PrintWriter writer = new LFPrintWriter(Files.newBufferedWriter(path))) {
 				for (ClassEntry classEntry : classes) {
 					progress.step(steps++, classEntry.getFullName());
 					writeRoot(writer, mappings, classEntry);
@@ -78,7 +79,7 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 					Files.deleteIfExists(classPath);
 					Files.createDirectories(classPath.getParent());
 
-					try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(classPath))) {
+					try (PrintWriter writer = new LFPrintWriter(Files.newBufferedWriter(classPath))) {
 						writeRoot(writer, mappings, classEntry);
 					}
 				} catch (Throwable t) {

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/SrgMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/SrgMappingsWriter.java
@@ -13,6 +13,7 @@ import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.translation.representation.entry.FieldEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import cuchaz.enigma.utils.LFPrintWriter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -52,7 +53,7 @@ public enum SrgMappingsWriter implements MappingsWriter {
 		}
 
 		progress.init(3, "Writing mappings");
-		try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(path))) {
+		try (PrintWriter writer = new LFPrintWriter(Files.newBufferedWriter(path))) {
 			progress.step(0, "Classes");
 			classLines.forEach(writer::println);
 			progress.step(1, "Fields");

--- a/src/main/java/cuchaz/enigma/utils/LFPrintWriter.java
+++ b/src/main/java/cuchaz/enigma/utils/LFPrintWriter.java
@@ -1,0 +1,16 @@
+package cuchaz.enigma.utils;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+
+public class LFPrintWriter extends PrintWriter {
+	public LFPrintWriter(Writer out) {
+		super(out);
+	}
+
+	@Override
+	public void println() {
+		// https://stackoverflow.com/a/14749004
+		write('\n');
+	}
+}


### PR DESCRIPTION
Done by changing the `PrintWriter`s in the mapping writer classes to a custom implementation overriding `println()`. Closes #87.