### PR TITLE
Bridge Method Fixes

### DIFF
--- a/src/main/java/cuchaz/enigma/Deobfuscator.java
+++ b/src/main/java/cuchaz/enigma/Deobfuscator.java
@@ -214,7 +214,7 @@ public class Deobfuscator {
 					ClassNode node = parsedJar.getClassNode(entry.getFullName());
 					if (node != null) {
 						ClassNode translatedNode = new ClassNode();
-						node.accept(new TranslationClassVisitor(jarIndex, translator, Opcodes.ASM5, translatedNode));
+						node.accept(new TranslationClassVisitor(translator, Opcodes.ASM5, translatedNode));
 						return translatedNode;
 					}
 
@@ -282,7 +282,7 @@ public class Deobfuscator {
 		Translator deobfuscator = mapper.getDeobfuscator();
 		writeTransformedJar(out, progress, (node, visitor) -> {
 			ClassEntry entry = new ClassEntry(node.name);
-			node.accept(new TranslationClassVisitor(jarIndex, deobfuscator, Opcodes.ASM5, visitor));
+			node.accept(new TranslationClassVisitor(deobfuscator, Opcodes.ASM5, visitor));
 			return deobfuscator.translate(entry).getFullName();
 		});
 	}

--- a/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
@@ -34,12 +34,14 @@ public class BridgeMethodIndex implements JarIndexer {
 	public void processIndex(EntryResolver resolver) {
 		// look for access and bridged methods
 		for (MethodEntry methodEntry : entryIndex.getMethods()) {
-			AccessFlags access = entryIndex.getMethodAccess(methodEntry);
+			MethodDefEntry methodDefEntry = (MethodDefEntry) methodEntry;
+
+			AccessFlags access = methodDefEntry.getAccess();
 			if (access == null || !access.isSynthetic()) {
 				continue;
 			}
 
-			indexSyntheticMethod((MethodDefEntry) methodEntry, access);
+			indexSyntheticMethod(methodDefEntry, access);
 		}
 	}
 

--- a/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
@@ -53,10 +53,6 @@ public class BridgeMethodIndex implements JarIndexer {
 			return;
 		}
 
-		if (access.isBridge() && !isPotentialBridge(syntheticMethod, accessedMethod)) {
-			System.out.println("we don't agree here!");
-		}
-
 		if (access.isBridge() || isPotentialBridge(syntheticMethod, accessedMethod)) {
 			bridgeMethods.add(syntheticMethod);
 			accessedToBridge.put(accessedMethod, syntheticMethod);

--- a/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
@@ -34,10 +34,6 @@ public class BridgeMethodIndex implements JarIndexer {
 	public void processIndex(EntryResolver resolver) {
 		// look for access and bridged methods
 		for (MethodEntry methodEntry : entryIndex.getMethods()) {
-			if (methodEntry.getParent().getName().equals("fn") && (methodEntry.getName().equals("compareTo") || methodEntry.getName().equals("l"))) {
-				System.out.println();
-			}
-
 			AccessFlags access = entryIndex.getMethodAccess(methodEntry);
 			if (access == null || !access.isSynthetic()) {
 				continue;

--- a/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
@@ -46,9 +46,9 @@ public class JarIndex implements JarIndexer {
 
 	public static JarIndex empty() {
 		EntryIndex entryIndex = new EntryIndex();
-		InheritanceIndex inheritanceIndex = new InheritanceIndex();
+		InheritanceIndex inheritanceIndex = new InheritanceIndex(entryIndex);
 		ReferenceIndex referenceIndex = new ReferenceIndex();
-		BridgeMethodIndex bridgeMethodIndex = new BridgeMethodIndex(entryIndex, referenceIndex);
+		BridgeMethodIndex bridgeMethodIndex = new BridgeMethodIndex(entryIndex, inheritanceIndex, referenceIndex);
 		return new JarIndex(entryIndex, inheritanceIndex, referenceIndex, bridgeMethodIndex);
 	}
 

--- a/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
@@ -1,0 +1,43 @@
+package cuchaz.enigma.bytecode.translators;
+
+import cuchaz.enigma.analysis.index.BridgeMethodIndex;
+import cuchaz.enigma.analysis.index.JarIndex;
+import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
+import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class SourceFixVisitor extends ClassVisitor {
+	private final JarIndex index;
+	private ClassDefEntry ownerEntry;
+
+	public SourceFixVisitor(int api, ClassVisitor visitor, JarIndex index) {
+		super(api, visitor);
+		this.index = index;
+	}
+
+	@Override
+	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+		ownerEntry = ClassDefEntry.parse(access, name, signature, superName, interfaces);
+		super.visit(version, access, name, signature, superName, interfaces);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+		MethodDefEntry methodEntry = MethodDefEntry.parse(ownerEntry, access, name, descriptor, signature);
+
+		BridgeMethodIndex bridgeIndex = index.getBridgeMethodIndex();
+		if (bridgeIndex.isBridgeMethod(methodEntry)) {
+			access |= Opcodes.ACC_BRIDGE;
+		} else {
+			MethodEntry bridgeMethod = bridgeIndex.getBridgeFromAccessed(methodEntry);
+			if (bridgeMethod != null) {
+				name = bridgeMethod.getName();
+			}
+		}
+
+		return super.visitMethod(access, name, descriptor, signature, exceptions);
+	}
+}

--- a/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
@@ -11,9 +11,7 @@
 
 package cuchaz.enigma.bytecode.translators;
 
-import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.translation.Translator;
-import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.MethodDescriptor;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.*;
@@ -22,14 +20,12 @@ import org.objectweb.asm.*;
 import java.util.Arrays;
 
 public class TranslationClassVisitor extends ClassVisitor {
-	private final JarIndex index;
 	private final Translator translator;
 
 	private ClassDefEntry obfClassEntry;
 
-	public TranslationClassVisitor(JarIndex index, Translator translator, int api, ClassVisitor cv) {
+	public TranslationClassVisitor(Translator translator, int api, ClassVisitor cv) {
 		super(api, cv);
-		this.index = index;
 		this.translator = translator;
 	}
 
@@ -60,8 +56,7 @@ public class TranslationClassVisitor extends ClassVisitor {
 		for (int i = 0; i < exceptions.length; i++) {
 			translatedExceptions[i] = translator.translate(new ClassEntry(exceptions[i])).getFullName();
 		}
-		AccessFlags translatedAccess = translatedEntry.getAccess();
-		MethodVisitor mv = super.visitMethod(translatedAccess.getFlags(), translatedEntry.getName(), translatedEntry.getDesc().toString(), translatedEntry.getSignature().toString(), translatedExceptions);
+		MethodVisitor mv = super.visitMethod(translatedEntry.getAccess().getFlags(), translatedEntry.getName(), translatedEntry.getDesc().toString(), translatedEntry.getSignature().toString(), translatedExceptions);
 		return new TranslationMethodVisitor(translator, obfClassEntry, entry, api, mv);
 	}
 

--- a/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
@@ -11,7 +11,9 @@
 
 package cuchaz.enigma.bytecode.translators;
 
+import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.MethodDescriptor;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.*;
@@ -20,12 +22,14 @@ import org.objectweb.asm.*;
 import java.util.Arrays;
 
 public class TranslationClassVisitor extends ClassVisitor {
+	private final JarIndex index;
 	private final Translator translator;
 
 	private ClassDefEntry obfClassEntry;
 
-	public TranslationClassVisitor(Translator translator, int api, ClassVisitor cv) {
+	public TranslationClassVisitor(JarIndex index, Translator translator, int api, ClassVisitor cv) {
 		super(api, cv);
+		this.index = index;
 		this.translator = translator;
 	}
 
@@ -56,7 +60,8 @@ public class TranslationClassVisitor extends ClassVisitor {
 		for (int i = 0; i < exceptions.length; i++) {
 			translatedExceptions[i] = translator.translate(new ClassEntry(exceptions[i])).getFullName();
 		}
-		MethodVisitor mv = super.visitMethod(translatedEntry.getAccess().getFlags(), translatedEntry.getName(), translatedEntry.getDesc().toString(), translatedEntry.getSignature().toString(), translatedExceptions);
+		AccessFlags translatedAccess = translatedEntry.getAccess();
+		MethodVisitor mv = super.visitMethod(translatedAccess.getFlags(), translatedEntry.getName(), translatedEntry.getDesc().toString(), translatedEntry.getSignature().toString(), translatedExceptions);
 		return new TranslationMethodVisitor(translator, obfClassEntry, entry, api, mv);
 	}
 


### PR DESCRIPTION
This PR allows `BridgeMethodIndex` to detect synthetic methods not marked as bridges by performing a series of checks. Additionally, bytecode is now processed to attach the bridge modifier to methods missing it, and fix names such that they match their bridge equivalent.

I am not certain on the validity of them, and how possible it'd be to get false-positives.