### PR TITLE
Rename in place functionality

### DIFF
--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -77,6 +77,8 @@ public class Gui {
 	private JList<Token> tokens;
 	private JTabbedPane tabs;
 
+	public JTextField renameTextField;
+
 	public void setEditorTheme(Config.LookAndFeel feel) {
 		if (editor != null && (editorFeel == null || editorFeel != feel)) {
 			editor.updateUI();
@@ -588,22 +590,22 @@ public class Gui {
 	public void startRename() {
 
 		// init the text box
-		final JTextField text = new JTextField();
+		renameTextField = new JTextField();
 
 		EntryReference<Entry<?>, Entry<?>> translatedReference = controller.getDeobfuscator().deobfuscate(reference);
-		text.setText(translatedReference.getNameableName());
+		renameTextField.setText(translatedReference.getNameableName());
 
-		text.setPreferredSize(new Dimension(360, text.getPreferredSize().height));
-		text.addKeyListener(new KeyAdapter() {
+		renameTextField.setPreferredSize(new Dimension(360, renameTextField.getPreferredSize().height));
+		renameTextField.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyPressed(KeyEvent event) {
 				switch (event.getKeyCode()) {
 					case KeyEvent.VK_ENTER:
-						finishRename(text, true);
+						finishRename(true);
 						break;
 
 					case KeyEvent.VK_ESCAPE:
-						finishRename(text, false);
+						finishRename(false);
 						break;
 					default:
 						break;
@@ -614,28 +616,28 @@ public class Gui {
 		// find the label with the name and replace it with the text box
 		JPanel panel = (JPanel) infoPanel.getComponent(0);
 		panel.remove(panel.getComponentCount() - 1);
-		panel.add(text);
-		text.grabFocus();
+		panel.add(renameTextField);
+		renameTextField.grabFocus();
 
-		int offset = text.getText().lastIndexOf('/') + 1;
+		int offset = renameTextField.getText().lastIndexOf('/') + 1;
 		// If it's a class and isn't in the default package, assume that it's deobfuscated.
-		if (translatedReference.getNameableEntry() instanceof ClassEntry && text.getText().contains("/") && offset != 0)
-			text.select(offset, text.getText().length());
+		if (translatedReference.getNameableEntry() instanceof ClassEntry && renameTextField.getText().contains("/") && offset != 0)
+			renameTextField.select(offset, renameTextField.getText().length());
 		else
-			text.selectAll();
+			renameTextField.selectAll();
 
 		redraw();
 	}
 
-	private void finishRename(JTextField text, boolean saveName) {
-		String newName = text.getText();
+	private void finishRename(boolean saveName) {
+		String newName = renameTextField.getText();
 		if (saveName && newName != null && !newName.isEmpty()) {
 			try {
 				this.controller.rename(reference, newName, true);
 			} catch (IllegalNameException ex) {
-				text.setBorder(BorderFactory.createLineBorder(Color.red, 1));
-				text.setToolTipText(ex.getReason());
-				Utils.showToolTipNow(text);
+				renameTextField.setBorder(BorderFactory.createLineBorder(Color.red, 1));
+				renameTextField.setToolTipText(ex.getReason());
+				Utils.showToolTipNow(renameTextField);
 			}
 			return;
 		}
@@ -644,6 +646,8 @@ public class Gui {
 		JPanel panel = (JPanel) infoPanel.getComponent(0);
 		panel.remove(panel.getComponentCount() - 1);
 		panel.add(Utils.unboldLabel(new JLabel(reference.getNameableName(), JLabel.LEFT)));
+
+		renameTextField = null;
 
 		this.editor.grabFocus();
 

--- a/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -273,20 +273,23 @@ public class GuiController {
 	}
 
 	private void showReference(EntryReference<Entry<?>, Entry<?>> reference) {
-		EntryRemapper mapper = this.deobfuscator.getMapper();
-
-		SourceIndex index = this.currentSource.getIndex();
-		Collection<Token> tokens = mapper.getObfResolver().resolveReference(reference, ResolutionStrategy.RESOLVE_CLOSEST)
-				.stream()
-				.flatMap(r -> index.getReferenceTokens(r).stream())
-				.collect(Collectors.toList());
-
+		Collection<Token> tokens = getTokensForReference(reference);
 		if (tokens.isEmpty()) {
 			// DEBUG
 			System.err.println(String.format("WARNING: no tokens found for %s in %s", reference, this.currentSource.getEntry()));
 		} else {
 			this.gui.showTokens(tokens);
 		}
+	}
+
+	public Collection<Token> getTokensForReference(EntryReference<Entry<?>, Entry<?>> reference) {
+		EntryRemapper mapper = this.deobfuscator.getMapper();
+
+		SourceIndex index = this.currentSource.getIndex();
+		return mapper.getObfResolver().resolveReference(reference, ResolutionStrategy.RESOLVE_CLOSEST)
+				.stream()
+				.flatMap(r -> index.getReferenceTokens(r).stream())
+				.collect(Collectors.toList());
 	}
 
 	public void savePreviousReference(EntryReference<Entry<?>, Entry<?>> reference) {

--- a/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
+++ b/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
@@ -41,10 +41,6 @@ public class PanelEditor extends JEditorPane {
 			public void keyPressed(KeyEvent event) {
 				if (event.isControlDown()) {
 					switch (event.getKeyCode()) {
-						case KeyEvent.VK_R:
-							gui.popupMenu.renameMenu.doClick();
-							break;
-
 						case KeyEvent.VK_I:
 							gui.popupMenu.showInheritanceMenu.doClick();
 							break;
@@ -85,7 +81,7 @@ public class PanelEditor extends JEditorPane {
 
 			@Override
 			public void keyTyped(KeyEvent event) {
-				if (!gui.popupMenu.isEnabled()) return;
+				if (!gui.popupMenu.renameMenu.isEnabled()) return;
 				if (!event.isControlDown() && !event.isAltDown()) {
 					gui.popupMenu.renameMenu.doClick();
 					gui.renameTextField.setText(String.valueOf(event.getKeyChar()));

--- a/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
+++ b/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
@@ -28,47 +28,56 @@ public class PanelEditor extends JEditorPane {
 		this.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyPressed(KeyEvent event) {
-				switch (event.getKeyCode()) {
-					case KeyEvent.VK_R:
-						gui.popupMenu.renameMenu.doClick();
-						break;
+				if (event.isControlDown()) {
+					switch (event.getKeyCode()) {
+						case KeyEvent.VK_R:
+							gui.popupMenu.renameMenu.doClick();
+							break;
 
-					case KeyEvent.VK_I:
-						gui.popupMenu.showInheritanceMenu.doClick();
-						break;
+						case KeyEvent.VK_I:
+							gui.popupMenu.showInheritanceMenu.doClick();
+							break;
 
-					case KeyEvent.VK_M:
-						gui.popupMenu.showImplementationsMenu.doClick();
-						break;
+						case KeyEvent.VK_M:
+							gui.popupMenu.showImplementationsMenu.doClick();
+							break;
 
-					case KeyEvent.VK_N:
-						gui.popupMenu.openEntryMenu.doClick();
-						break;
+						case KeyEvent.VK_N:
+							gui.popupMenu.openEntryMenu.doClick();
+							break;
 
-					case KeyEvent.VK_P:
-						gui.popupMenu.openPreviousMenu.doClick();
-						break;
+						case KeyEvent.VK_P:
+							gui.popupMenu.openPreviousMenu.doClick();
+							break;
 
-					case KeyEvent.VK_C:
-						gui.popupMenu.showCallsMenu.doClick();
-						break;
+						case KeyEvent.VK_C:
+							gui.popupMenu.showCallsMenu.doClick();
+							break;
 
-					case KeyEvent.VK_O:
-						gui.popupMenu.toggleMappingMenu.doClick();
-						break;
-					case KeyEvent.VK_F5:
-						gui.getController().refreshCurrentClass();
-						break;
-					default:
-						break;
+						case KeyEvent.VK_O:
+							gui.popupMenu.toggleMappingMenu.doClick();
+							break;
+						case KeyEvent.VK_F5:
+							gui.getController().refreshCurrentClass();
+							break;
+						default:
+							break;
+					}
 				}
 
 				gui.setShouldNavigateOnClick(event.isControlDown());
 			}
 
 			@Override
+			public void keyTyped(KeyEvent event) {
+				if (!event.isControlDown() && !event.isAltDown()) {
+					gui.popupMenu.renameMenu.doClick();
+					gui.renameTextField.setText(String.valueOf(event.getKeyChar()));
+				}
+			}
+
+			@Override
 			public void keyReleased(KeyEvent event) {
-				super.keyReleased(event);
 				gui.setShouldNavigateOnClick(event.isControlDown());
 			}
 		});

--- a/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
+++ b/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
@@ -70,6 +70,7 @@ public class PanelEditor extends JEditorPane {
 
 			@Override
 			public void keyTyped(KeyEvent event) {
+				if (!gui.popupMenu.isEnabled()) return;
 				if (!event.isControlDown() && !event.isAltDown()) {
 					gui.popupMenu.renameMenu.doClick();
 					gui.renameTextField.setText(String.valueOf(event.getKeyChar()));


### PR DESCRIPTION
This PR changes the editor to open the rename dialog as soon as the user starts typing on a nameable token.

However, this does break existing functionality. Hotkeys such as `R` to rename and `N` to navigate can no longer be used as they were before, because it'd be impossible to distinguish these from normal typing. The solution here is to mask them with the control modifier.

Definitely will need opinions from people on these changes before merging.