### PR TITLE
Quick find fixes

### DIFF
--- a/src/main/java/cuchaz/enigma/gui/EnigmaQuickFindDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/EnigmaQuickFindDialog.java
@@ -6,12 +6,30 @@ import de.sciss.syntaxpane.actions.gui.QuickFindDialog;
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class EnigmaQuickFindDialog extends QuickFindDialog {
 	public EnigmaQuickFindDialog(JTextComponent target) {
 		super(target, DocumentSearchData.getFromEditor(target));
+
+		JToolBar toolBar = getToolBar();
+		JTextField textField = getTextField(toolBar);
+
+		textField.addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyPressed(KeyEvent e) {
+				super.keyPressed(e);
+				if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+					JToolBar toolBar = getToolBar();
+					boolean next = !e.isShiftDown();
+					JButton button = next ? getNextButton(toolBar) : getPrevButton(toolBar);
+					button.doClick();
+				}
+			}
+		});
 	}
 
 	@Override
@@ -42,6 +60,16 @@ public class EnigmaQuickFindDialog extends QuickFindDialog {
 
 	private JTextField getTextField(JToolBar toolBar) {
 		return components(toolBar, JTextField.class).findFirst().orElse(null);
+	}
+
+	private JButton getNextButton(JToolBar toolBar) {
+		Stream<JButton> buttons = components(toolBar, JButton.class);
+		return buttons.skip(1).findFirst().orElse(null);
+	}
+
+	private JButton getPrevButton(JToolBar toolBar) {
+		Stream<JButton> buttons = components(toolBar, JButton.class);
+		return buttons.findFirst().orElse(null);
 	}
 
 	private static Stream<Component> components(Container container) {

--- a/src/main/java/cuchaz/enigma/gui/EnigmaQuickFindDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/EnigmaQuickFindDialog.java
@@ -1,0 +1,57 @@
+package cuchaz.enigma.gui;
+
+import de.sciss.syntaxpane.actions.DocumentSearchData;
+import de.sciss.syntaxpane.actions.gui.QuickFindDialog;
+
+import javax.swing.*;
+import javax.swing.text.JTextComponent;
+import java.awt.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class EnigmaQuickFindDialog extends QuickFindDialog {
+	public EnigmaQuickFindDialog(JTextComponent target) {
+		super(target, DocumentSearchData.getFromEditor(target));
+	}
+
+	@Override
+	public void showFor(JTextComponent target) {
+		String selectedText = target.getSelectedText();
+
+		super.showFor(target);
+
+		Container view = target.getParent();
+		Point loc = new Point(0, view.getHeight() - getSize().height);
+		setLocationRelativeTo(view);
+		SwingUtilities.convertPointToScreen(loc, view);
+		setLocation(loc);
+
+		JToolBar toolBar = getToolBar();
+		JTextField textField = getTextField(toolBar);
+
+		if (selectedText != null) {
+			textField.setText(selectedText);
+		}
+
+		textField.selectAll();
+	}
+
+	private JToolBar getToolBar() {
+		return components(getContentPane(), JToolBar.class).findFirst().orElse(null);
+	}
+
+	private JTextField getTextField(JToolBar toolBar) {
+		return components(toolBar, JTextField.class).findFirst().orElse(null);
+	}
+
+	private static Stream<Component> components(Container container) {
+		return IntStream.range(0, container.getComponentCount())
+				.mapToObj(container::getComponent);
+	}
+
+	private static <T extends Component> Stream<T> components(Container container, Class<T> type) {
+		return components(container)
+				.filter(type::isInstance)
+				.map(type::cast);
+	}
+}

--- a/src/main/java/cuchaz/enigma/gui/EnigmaSyntaxKit.java
+++ b/src/main/java/cuchaz/enigma/gui/EnigmaSyntaxKit.java
@@ -34,6 +34,8 @@ public class EnigmaSyntaxKit extends JavaSyntaxKit {
         configuration.put(LineNumbersRuler.PROPERTY_FOREGROUND, Config.getInstance().lineNumbersForeground + "");
         configuration.put(LineNumbersRuler.PROPERTY_CURRENT_BACK, Config.getInstance().lineNumbersSelected + "");
         configuration.put("RightMarginColumn", "999"); //No need to have a right margin, if someone wants it add a config
+
+        configuration.put("Action.quick-find", "cuchaz.enigma.gui.QuickFindAction, menu F");
     }
 
     public static void invalidate(){

--- a/src/main/java/cuchaz/enigma/gui/QuickFindAction.java
+++ b/src/main/java/cuchaz/enigma/gui/QuickFindAction.java
@@ -1,0 +1,45 @@
+package cuchaz.enigma.gui;
+
+import de.sciss.syntaxpane.SyntaxDocument;
+import de.sciss.syntaxpane.actions.DefaultSyntaxAction;
+
+import javax.swing.text.JTextComponent;
+import java.awt.event.ActionEvent;
+
+public final class QuickFindAction extends DefaultSyntaxAction {
+	public QuickFindAction() {
+		super("quick-find");
+	}
+
+	@Override
+	public void actionPerformed(JTextComponent target, SyntaxDocument document, int dot, ActionEvent event) {
+		Data data = Data.get(target);
+		data.showFindDialog(target);
+	}
+
+	private static class Data {
+		private static final String KEY = "enigma-find-data";
+		private EnigmaQuickFindDialog findDialog;
+
+		private Data() {
+		}
+
+		public static Data get(JTextComponent target) {
+			Object o = target.getDocument().getProperty(KEY);
+			if (o instanceof Data) {
+				return (Data) o;
+			}
+
+			Data data = new Data();
+			target.getDocument().putProperty(KEY, data);
+			return data;
+		}
+
+		public void showFindDialog(JTextComponent target) {
+			if (findDialog == null) {
+				findDialog = new EnigmaQuickFindDialog(target);
+			}
+			findDialog.showFor(target);
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes the quick find dialog to correctly fit within the screen.
Additionally, the dialog will now select all text on open allowing it to be easily replaced, and if any text is highlighted in the editor, it will be set in the find dialog on open