### PR TITLE
checkmappings command

### DIFF
--- a/src/main/java/cuchaz/enigma/CommandMain.java
+++ b/src/main/java/cuchaz/enigma/CommandMain.java
@@ -51,6 +51,7 @@ public class CommandMain {
 		} catch (IllegalArgumentException ex) {
 			System.err.println(ex.getMessage());
 			printHelp();
+			System.exit(1);
 		}
 	}
 
@@ -126,11 +127,18 @@ public class CommandMain {
 
 		JarIndex idx = deobfuscator.getJarIndex();
 
+		boolean error = false;
+
 		for (Set<ClassEntry> partition : idx.getPackageVisibilityIndex().getPartitions()) {
 			long packages = partition.stream().map(deobfuscator.getMapper()::deobfuscate).map(ClassEntry::getPackageName).distinct().count();
 			if (packages > 1) {
+				error = true;
 				System.err.println("ERROR: Must be in one package:\n" + partition.stream().map(deobfuscator.getMapper()::deobfuscate).map(ClassEntry::toString).sorted().collect(Collectors.joining("\n")));
 			}
+		}
+
+		if (error) {
+			System.exit(1);
 		}
 	}
 

--- a/src/main/java/cuchaz/enigma/CommandMain.java
+++ b/src/main/java/cuchaz/enigma/CommandMain.java
@@ -138,7 +138,7 @@ public class CommandMain {
 		}
 
 		if (error) {
-			System.exit(1);
+			throw new Exception("Access violations detected");
 		}
 	}
 

--- a/src/main/java/cuchaz/enigma/analysis/index/EntryIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/EntryIndex.java
@@ -65,6 +65,11 @@ public class EntryIndex implements JarIndexer {
 	}
 
 	@Nullable
+	public AccessFlags getClassAccess(ClassEntry entry) {
+		return classes.get(entry);
+	}
+
+	@Nullable
 	public AccessFlags getEntryAccess(Entry<?> entry) {
 		if (entry instanceof MethodEntry) {
 			return getMethodAccess((MethodEntry) entry);

--- a/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
@@ -29,18 +29,20 @@ public class JarIndex implements JarIndexer {
 	private final InheritanceIndex inheritanceIndex;
 	private final ReferenceIndex referenceIndex;
 	private final BridgeMethodIndex bridgeMethodIndex;
+	private final PackageVisibilityIndex packageVisibilityIndex;
 	private final EntryResolver entryResolver;
 
 	private final Collection<JarIndexer> indexers;
 
 	private final Multimap<String, MethodDefEntry> methodImplementations = HashMultimap.create();
 
-	public JarIndex(EntryIndex entryIndex, InheritanceIndex inheritanceIndex, ReferenceIndex referenceIndex, BridgeMethodIndex bridgeMethodIndex) {
+	public JarIndex(EntryIndex entryIndex, InheritanceIndex inheritanceIndex, ReferenceIndex referenceIndex, BridgeMethodIndex bridgeMethodIndex, PackageVisibilityIndex packageVisibilityIndex) {
 		this.entryIndex = entryIndex;
 		this.inheritanceIndex = inheritanceIndex;
 		this.referenceIndex = referenceIndex;
 		this.bridgeMethodIndex = bridgeMethodIndex;
-		this.indexers = Arrays.asList(entryIndex, inheritanceIndex, referenceIndex, bridgeMethodIndex);
+		this.packageVisibilityIndex = packageVisibilityIndex;
+		this.indexers = Arrays.asList(entryIndex, inheritanceIndex, referenceIndex, bridgeMethodIndex, packageVisibilityIndex);
 		this.entryResolver = new IndexEntryResolver(this);
 	}
 
@@ -49,7 +51,8 @@ public class JarIndex implements JarIndexer {
 		InheritanceIndex inheritanceIndex = new InheritanceIndex(entryIndex);
 		ReferenceIndex referenceIndex = new ReferenceIndex();
 		BridgeMethodIndex bridgeMethodIndex = new BridgeMethodIndex(entryIndex, inheritanceIndex, referenceIndex);
-		return new JarIndex(entryIndex, inheritanceIndex, referenceIndex, bridgeMethodIndex);
+		PackageVisibilityIndex packageVisibilityIndex = new PackageVisibilityIndex();
+		return new JarIndex(entryIndex, inheritanceIndex, referenceIndex, bridgeMethodIndex, packageVisibilityIndex);
 	}
 
 	public void indexJar(ParsedJar jar, Consumer<String> progress) {
@@ -140,6 +143,10 @@ public class JarIndex implements JarIndexer {
 
 	public BridgeMethodIndex getBridgeMethodIndex() {
 		return bridgeMethodIndex;
+	}
+
+	public PackageVisibilityIndex getPackageVisibilityIndex() {
+		return packageVisibilityIndex;
 	}
 
 	public EntryResolver getEntryResolver() {

--- a/src/main/java/cuchaz/enigma/analysis/index/PackageVisibilityIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/PackageVisibilityIndex.java
@@ -14,27 +14,10 @@ public class PackageVisibilityIndex implements JarIndexer {
 	private static boolean isPackageVisibleOnlyRef(AccessFlags entryAcc, EntryReference ref, InheritanceIndex inheritanceIndex) {
 		if (entryAcc.isPublic()) return false;
 		if (entryAcc.isProtected()) {
-			// TODO: Is this valid?
-			for (ClassEntry outerClass : getOuterClasses(ref.context.getContainingClass())) {
-				Set<ClassEntry> callerAncestors = inheritanceIndex.getAncestors(outerClass);
-				if (callerAncestors.contains(ref.entry.getContainingClass())) {
-					return false;
-				}
-			}
+			Set<ClassEntry> callerAncestors = inheritanceIndex.getAncestors(ref.context.getContainingClass());
+			return !callerAncestors.contains(ref.entry.getContainingClass());
 		}
-		return !entryAcc.isPrivate();
-	}
-
-	private static Collection<ClassEntry> getOuterClasses(ClassEntry entry) {
-		Collection<ClassEntry> outerClasses = new ArrayList<>();
-
-		ClassEntry currentEntry = entry;
-		while (currentEntry != null) {
-			outerClasses.add(currentEntry);
-			currentEntry = currentEntry.getOuterClass();
-		}
-
-		return outerClasses;
+		return !entryAcc.isPrivate(); // if isPrivate is false, it must be package-private
 	}
 
 	private final HashMultimap<ClassEntry, ClassEntry> connections = HashMultimap.create();

--- a/src/main/java/cuchaz/enigma/analysis/index/PackageVisibilityIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/PackageVisibilityIndex.java
@@ -1,0 +1,144 @@
+package cuchaz.enigma.analysis.index;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import cuchaz.enigma.analysis.EntryReference;
+import cuchaz.enigma.translation.representation.AccessFlags;
+import cuchaz.enigma.translation.representation.entry.*;
+
+import java.util.*;
+
+public class PackageVisibilityIndex implements JarIndexer {
+	private static boolean isPackageVisibleOnlyRef(AccessFlags entryAcc, EntryReference ref, InheritanceIndex inheritanceIndex) {
+		if (entryAcc.isPublic()) return false;
+		if (entryAcc.isProtected()) {
+			// TODO: Is this valid?
+			for (ClassEntry outerClass : getOuterClasses(ref.context.getContainingClass())) {
+				Set<ClassEntry> callerAncestors = inheritanceIndex.getAncestors(outerClass);
+				if (callerAncestors.contains(ref.entry.getContainingClass())) {
+					return false;
+				}
+			}
+		}
+		return !entryAcc.isPrivate();
+	}
+
+	private static Collection<ClassEntry> getOuterClasses(ClassEntry entry) {
+		Collection<ClassEntry> outerClasses = new ArrayList<>();
+
+		ClassEntry currentEntry = entry;
+		while (currentEntry != null) {
+			outerClasses.add(currentEntry);
+			currentEntry = currentEntry.getOuterClass();
+		}
+
+		return outerClasses;
+	}
+
+	private final HashMultimap<ClassEntry, ClassEntry> connections = HashMultimap.create();
+	private final List<Set<ClassEntry>> partitions = Lists.newArrayList();
+	private final Map<ClassEntry, Set<ClassEntry>> classPartitions = Maps.newHashMap();
+
+	private void addConnection(ClassEntry classA, ClassEntry classB) {
+		connections.put(classA, classB);
+		connections.put(classB, classA);
+	}
+
+	private void buildPartition(Set<ClassEntry> unassignedClasses, Set<ClassEntry> partition, ClassEntry member) {
+		for (ClassEntry connected : connections.get(member)) {
+			if (unassignedClasses.remove(connected)) {
+				partition.add(connected);
+				buildPartition(unassignedClasses, partition, connected);
+			}
+		}
+	}
+
+	private void addConnections(EntryIndex entryIndex, ReferenceIndex referenceIndex, InheritanceIndex inheritanceIndex) {
+		for (FieldEntry entry : entryIndex.getFields()) {
+			AccessFlags entryAcc = entryIndex.getFieldAccess(entry);
+			if (!entryAcc.isPublic() && !entryAcc.isPrivate()) {
+				for (EntryReference<FieldEntry, MethodDefEntry> ref : referenceIndex.getReferencesToField(entry)) {
+					if (isPackageVisibleOnlyRef(entryAcc, ref, inheritanceIndex)) {
+						addConnection(ref.entry.getContainingClass(), ref.context.getContainingClass());
+					}
+				}
+			}
+		}
+
+		for (MethodEntry entry : entryIndex.getMethods()) {
+			AccessFlags entryAcc = entryIndex.getMethodAccess(entry);
+			if (!entryAcc.isPublic() && !entryAcc.isPrivate()) {
+				for (EntryReference<MethodEntry, MethodDefEntry> ref : referenceIndex.getReferencesToMethod(entry)) {
+					if (isPackageVisibleOnlyRef(entryAcc, ref, inheritanceIndex)) {
+						addConnection(ref.entry.getContainingClass(), ref.context.getContainingClass());
+					}
+				}
+			}
+		}
+
+		for (ClassEntry entry : entryIndex.getClasses()) {
+			AccessFlags entryAcc = entryIndex.getClassAccess(entry);
+			if (!entryAcc.isPublic() && !entryAcc.isPrivate()) {
+				for (EntryReference<ClassEntry, FieldDefEntry> ref : referenceIndex.getFieldTypeReferencesToClass(entry)) {
+					if (isPackageVisibleOnlyRef(entryAcc, ref, inheritanceIndex)) {
+						addConnection(ref.entry.getContainingClass(), ref.context.getContainingClass());
+					}
+				}
+
+				for (EntryReference<ClassEntry, MethodDefEntry> ref : referenceIndex.getMethodTypeReferencesToClass(entry)) {
+					if (isPackageVisibleOnlyRef(entryAcc, ref, inheritanceIndex)) {
+						addConnection(ref.entry.getContainingClass(), ref.context.getContainingClass());
+					}
+				}
+			}
+
+			for (ClassEntry parent : inheritanceIndex.getParents(entry)) {
+				AccessFlags parentAcc = entryIndex.getClassAccess(parent);
+				if (parentAcc != null && !parentAcc.isPublic() && !parentAcc.isPrivate()) {
+					addConnection(entry, parent);
+				}
+			}
+
+			ClassEntry outerClass = entry.getOuterClass();
+			if (outerClass != null) {
+				addConnection(entry, outerClass);
+			}
+		}
+	}
+
+	private void addPartitions(EntryIndex entryIndex) {
+		Set<ClassEntry> unassignedClasses = Sets.newHashSet(entryIndex.getClasses());
+		while (!unassignedClasses.isEmpty()) {
+			Iterator<ClassEntry> iterator = unassignedClasses.iterator();
+			ClassEntry initialEntry = iterator.next();
+			iterator.remove();
+
+			HashSet<ClassEntry> partition = Sets.newHashSet();
+			partition.add(initialEntry);
+			buildPartition(unassignedClasses, partition, initialEntry);
+			partitions.add(partition);
+			for (ClassEntry entry : partition) {
+				classPartitions.put(entry, partition);
+			}
+		}
+	}
+
+	public Collection<Set<ClassEntry>> getPartitions() {
+		return partitions;
+	}
+
+	public Set<ClassEntry> getPartition(ClassEntry classEntry) {
+		return classPartitions.get(classEntry);
+	}
+
+	@Override
+	public void processIndex(JarIndex index) {
+		EntryIndex entryIndex = index.getEntryIndex();
+		ReferenceIndex referenceIndex = index.getReferenceIndex();
+		InheritanceIndex inheritanceIndex = index.getInheritanceIndex();
+		addConnections(entryIndex, referenceIndex, inheritanceIndex);
+		addPartitions(entryIndex);
+	}
+}

--- a/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
@@ -41,7 +41,7 @@ public class ReferenceIndex implements JarIndexer {
 	}
 
 	private <K extends Entry<?>, V extends Entry<?>> Multimap<K, V> remapReferences(JarIndex index, Multimap<K, V> multimap) {
-		Multimap<K, V> resolved = HashMultimap.create();
+		Multimap<K, V> resolved = HashMultimap.create(multimap.keySet().size(), multimap.size() / multimap.keySet().size());
 		for (Map.Entry<K, V> entry : multimap.entries()) {
 			resolved.put(remap(index, entry.getKey()), remap(index, entry.getValue()));
 		}
@@ -49,7 +49,7 @@ public class ReferenceIndex implements JarIndexer {
 	}
 
 	private <E extends Entry<?>, C extends Entry<?>> Multimap<E, EntryReference<E, C>> remapReferencesTo(JarIndex index, Multimap<E, EntryReference<E, C>> multimap) {
-		Multimap<E, EntryReference<E, C>> resolved = HashMultimap.create();
+		Multimap<E, EntryReference<E, C>> resolved = HashMultimap.create(multimap.keySet().size(), multimap.size() / multimap.keySet().size());
 		for (Map.Entry<E, EntryReference<E, C>> entry : multimap.entries()) {
 			resolved.put(remap(index, entry.getKey()), remap(index, entry.getValue()));
 		}

--- a/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
@@ -4,6 +4,8 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import cuchaz.enigma.analysis.EntryReference;
 import cuchaz.enigma.translation.mapping.ResolutionStrategy;
+import cuchaz.enigma.translation.representation.MethodDescriptor;
+import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.*;
 
 import java.util.Collection;
@@ -15,6 +17,43 @@ public class ReferenceIndex implements JarIndexer {
 	private Multimap<MethodEntry, EntryReference<MethodEntry, MethodDefEntry>> referencesToMethods = HashMultimap.create();
 	private Multimap<ClassEntry, EntryReference<ClassEntry, MethodDefEntry>> referencesToClasses = HashMultimap.create();
 	private Multimap<FieldEntry, EntryReference<FieldEntry, MethodDefEntry>> referencesToFields = HashMultimap.create();
+	private Multimap<ClassEntry, EntryReference<ClassEntry, FieldDefEntry>> fieldTypeReferences = HashMultimap.create();
+	private Multimap<ClassEntry, EntryReference<ClassEntry, MethodDefEntry>> methodTypeReferences = HashMultimap.create();
+
+	@Override
+	public void indexMethod(MethodDefEntry methodEntry) {
+	    indexMethodDescriptor(methodEntry, methodEntry.getDesc());
+	}
+
+	private void indexMethodDescriptor(MethodDefEntry entry, MethodDescriptor descriptor) {
+		for (TypeDescriptor typeDescriptor : descriptor.getArgumentDescs()) {
+			indexMethodTypeDescriptor(entry, typeDescriptor);
+		}
+		indexMethodTypeDescriptor(entry, descriptor.getReturnDesc());
+	}
+
+	private void indexMethodTypeDescriptor(MethodDefEntry method, TypeDescriptor typeDescriptor) {
+		if (typeDescriptor.isType()) {
+			ClassEntry referencedClass = typeDescriptor.getTypeEntry();
+			methodTypeReferences.put(referencedClass, new EntryReference<>(referencedClass, referencedClass.getName(), method));
+		} else if (typeDescriptor.isArray()) {
+			indexMethodTypeDescriptor(method, typeDescriptor.getArrayType());
+		}
+	}
+
+	@Override
+	public void indexField(FieldDefEntry fieldEntry) {
+	    indexFieldTypeDescriptor(fieldEntry, fieldEntry.getDesc());
+	}
+
+	private void indexFieldTypeDescriptor(FieldDefEntry field, TypeDescriptor typeDescriptor) {
+		if (typeDescriptor.isType()) {
+			ClassEntry referencedClass = typeDescriptor.getTypeEntry();
+			fieldTypeReferences.put(referencedClass, new EntryReference<>(referencedClass, referencedClass.getName(), field));
+		} else if (typeDescriptor.isArray()) {
+		    indexFieldTypeDescriptor(field, typeDescriptor.getArrayType());
+		}
+	}
 
 	@Override
 	public void indexMethodReference(MethodDefEntry callerEntry, MethodEntry referencedEntry) {
@@ -25,6 +64,8 @@ public class ReferenceIndex implements JarIndexer {
 			ClassEntry referencedClass = referencedEntry.getParent();
 			referencesToClasses.put(referencedClass, new EntryReference<>(referencedClass, referencedEntry.getName(), callerEntry));
 		}
+
+		indexMethodDescriptor(callerEntry, referencedEntry.getDesc());
 	}
 
 	@Override
@@ -38,6 +79,8 @@ public class ReferenceIndex implements JarIndexer {
 		referencesToMethods = remapReferencesTo(index, referencesToMethods);
 		referencesToClasses = remapReferencesTo(index, referencesToClasses);
 		referencesToFields = remapReferencesTo(index, referencesToFields);
+		fieldTypeReferences = remapReferencesTo(index, fieldTypeReferences);
+		methodTypeReferences = remapReferencesTo(index, methodTypeReferences);
 	}
 
 	private <K extends Entry<?>, V extends Entry<?>> Multimap<K, V> remapReferences(JarIndex index, Multimap<K, V> multimap) {
@@ -78,5 +121,13 @@ public class ReferenceIndex implements JarIndexer {
 
 	public Collection<EntryReference<MethodEntry, MethodDefEntry>> getReferencesToMethod(MethodEntry entry) {
 		return referencesToMethods.get(entry);
+	}
+
+	public Collection<EntryReference<ClassEntry, FieldDefEntry>> getFieldTypeReferencesToClass(ClassEntry entry) {
+		return fieldTypeReferences.get(entry);
+	}
+
+	public Collection<EntryReference<ClassEntry, MethodDefEntry>> getMethodTypeReferencesToClass(ClassEntry entry) {
+		return methodTypeReferences.get(entry);
 	}
 }


### PR DESCRIPTION
This PR introduces an index that partitions classes to identify which classes must exist in the same package, and more thoroughly recreates the functionality of the checkMappings command from Weave. The idea is that the index introduced here can be used in Enigma itself in the future.

In addition, this sets up exit codes and uses the System.err output for errors so we can hopefully use it in scripts.