### PR TITLE
Method type reference corrections

### DIFF
--- a/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Multimap;
 import cuchaz.enigma.analysis.ParsedJar;
 import cuchaz.enigma.translation.mapping.EntryResolver;
 import cuchaz.enigma.translation.mapping.IndexEntryResolver;
+import cuchaz.enigma.translation.representation.Lambda;
 import cuchaz.enigma.translation.representation.entry.*;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
@@ -127,6 +128,15 @@ public class JarIndex implements JarIndexer {
 		}
 
 		indexers.forEach(indexer -> indexer.indexFieldReference(callerEntry, referencedEntry));
+	}
+
+	@Override
+	public void indexLambda(MethodDefEntry callerEntry, Lambda lambda) {
+		if (callerEntry.getParent().isJre()) {
+			return;
+		}
+
+		indexers.forEach(indexer -> indexer.indexLambda(callerEntry, lambda));
 	}
 
 	public EntryIndex getEntryIndex() {

--- a/src/main/java/cuchaz/enigma/analysis/index/JarIndexer.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/JarIndexer.java
@@ -1,5 +1,6 @@
 package cuchaz.enigma.analysis.index;
 
+import cuchaz.enigma.translation.representation.Lambda;
 import cuchaz.enigma.translation.representation.entry.*;
 
 public interface JarIndexer {
@@ -16,6 +17,9 @@ public interface JarIndexer {
 	}
 
 	default void indexFieldReference(MethodDefEntry callerEntry, FieldEntry referencedEntry) {
+	}
+
+	default void indexLambda(MethodDefEntry callerEntry, Lambda lambda) {
 	}
 
 	default void processIndex(JarIndex index) {

--- a/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
@@ -4,6 +4,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import cuchaz.enigma.analysis.EntryReference;
 import cuchaz.enigma.translation.mapping.ResolutionStrategy;
+import cuchaz.enigma.translation.representation.Lambda;
 import cuchaz.enigma.translation.representation.MethodDescriptor;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.*;
@@ -64,13 +65,24 @@ public class ReferenceIndex implements JarIndexer {
 			ClassEntry referencedClass = referencedEntry.getParent();
 			referencesToClasses.put(referencedClass, new EntryReference<>(referencedClass, referencedEntry.getName(), callerEntry));
 		}
-
-		indexMethodDescriptor(callerEntry, referencedEntry.getDesc());
 	}
 
 	@Override
 	public void indexFieldReference(MethodDefEntry callerEntry, FieldEntry referencedEntry) {
 		referencesToFields.put(referencedEntry, new EntryReference<>(referencedEntry, referencedEntry.getName(), callerEntry));
+	}
+
+	@Override
+	public void indexLambda(MethodDefEntry callerEntry, Lambda lambda) {
+		if (lambda.getImplMethod() instanceof MethodEntry) {
+			indexMethodReference(callerEntry, (MethodEntry) lambda.getImplMethod());
+		} else {
+			indexFieldReference(callerEntry, (FieldEntry) lambda.getImplMethod());
+		}
+
+		indexMethodDescriptor(callerEntry, lambda.getInvokedType());
+		indexMethodDescriptor(callerEntry, lambda.getSamMethodType());
+		indexMethodDescriptor(callerEntry, lambda.getInstantiatedMethodType());
 	}
 
 	@Override

--- a/src/main/java/cuchaz/enigma/translation/representation/Lambda.java
+++ b/src/main/java/cuchaz/enigma/translation/representation/Lambda.java
@@ -1,0 +1,105 @@
+package cuchaz.enigma.translation.representation;
+
+import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMap;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.EntryResolver;
+import cuchaz.enigma.translation.mapping.ResolutionStrategy;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import cuchaz.enigma.translation.representation.entry.ParentedEntry;
+
+import java.util.Objects;
+
+public class Lambda implements Translatable {
+	private final String invokedName;
+	private final MethodDescriptor invokedType;
+	private final MethodDescriptor samMethodType;
+	private final ParentedEntry<?> implMethod;
+	private final MethodDescriptor instantiatedMethodType;
+
+	public Lambda(String invokedName, MethodDescriptor invokedType, MethodDescriptor samMethodType, ParentedEntry<?> implMethod, MethodDescriptor instantiatedMethodType) {
+		this.invokedName = invokedName;
+		this.invokedType = invokedType;
+		this.samMethodType = samMethodType;
+		this.implMethod = implMethod;
+		this.instantiatedMethodType = instantiatedMethodType;
+	}
+
+	@Override
+	public Lambda translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+		MethodEntry samMethod = new MethodEntry(getInterface(), invokedName, samMethodType);
+		EntryMapping samMethodMapping = resolveMapping(resolver, mappings, samMethod);
+
+		return new Lambda(
+			samMethodMapping != null ? samMethodMapping.getTargetName() : invokedName,
+			invokedType.translate(translator, resolver, mappings),
+			samMethodType.translate(translator, resolver, mappings),
+			implMethod.translate(translator, resolver, mappings),
+			instantiatedMethodType.translate(translator, resolver, mappings)
+		);
+	}
+
+	private EntryMapping resolveMapping(EntryResolver resolver, EntryMap<EntryMapping> mappings, MethodEntry methodEntry) {
+		for (MethodEntry entry : resolver.resolveEntry(methodEntry, ResolutionStrategy.RESOLVE_ROOT)) {
+			EntryMapping mapping = mappings.get(entry);
+			if (mapping != null) {
+				return mapping;
+			}
+		}
+		return null;
+	}
+
+	public ClassEntry getInterface() {
+		return invokedType.getReturnDesc().getTypeEntry();
+	}
+
+	public String getInvokedName() {
+		return invokedName;
+	}
+
+	public MethodDescriptor getInvokedType() {
+		return invokedType;
+	}
+
+	public MethodDescriptor getSamMethodType() {
+		return samMethodType;
+	}
+
+	public ParentedEntry<?> getImplMethod() {
+		return implMethod;
+	}
+
+	public MethodDescriptor getInstantiatedMethodType() {
+		return instantiatedMethodType;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Lambda lambda = (Lambda) o;
+		return Objects.equals(invokedName, lambda.invokedName) &&
+			Objects.equals(invokedType, lambda.invokedType) &&
+			Objects.equals(samMethodType, lambda.samMethodType) &&
+			Objects.equals(implMethod, lambda.implMethod) &&
+			Objects.equals(instantiatedMethodType, lambda.instantiatedMethodType);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(invokedName, invokedType, samMethodType, implMethod, instantiatedMethodType);
+	}
+
+	@Override
+	public String toString() {
+		return "Lambda{" +
+			"invokedName='" + invokedName + '\'' +
+			", invokedType=" + invokedType +
+			", samMethodType=" + samMethodType +
+			", implMethod=" + implMethod +
+			", instantiatedMethodType=" + instantiatedMethodType +
+			'}';
+	}
+}

--- a/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
+++ b/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
@@ -118,7 +118,7 @@ public class MethodDescriptor implements Translatable {
 	}
 
 	@Override
-	public Translatable translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+	public MethodDescriptor translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
 		List<TypeDescriptor> translatedArguments = new ArrayList<>(argumentDescs.size());
 		for (TypeDescriptor argument : argumentDescs) {
 			translatedArguments.add(translator.translate(argument));

--- a/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
+++ b/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
@@ -52,7 +52,7 @@ public abstract class ParentedEntry<P extends Entry<?>> implements Entry<P> {
 	}
 
 	@Override
-	public Translatable translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+	public ParentedEntry<P> translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
 		P parent = getParent();
 		EntryMapping mapping = resolveMapping(resolver, mappings);
 		if (parent == null) {


### PR DESCRIPTION
Further investigation shows that a method may call another method with an inaccessible package-private type as a parameter or a return value. Only the owner of the method matters. It is therefore incorrect to assume that a class does not depend on another class being in the same package based on the descriptor of the methods called.

Lambdas create rather special cases that are handled in this PR. It ties in with how LambdaMetaFactory works and the methods implemented in the generated lambda class.