### PR TITLE
Save unqualified inner class names

### DIFF
--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
@@ -205,7 +205,7 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 
 	protected String writeClass(ClassEntry entry, EntryMapping mapping) {
 		StringBuilder builder = new StringBuilder("CLASS ");
-		builder.append(entry.getFullName()).append(' ');
+		builder.append(entry.getName()).append(' ');
 		writeMapping(builder, mapping);
 
 		return builder.toString();


### PR DESCRIPTION
Should be merged together with https://github.com/sfPlayer1/Matcher/pull/4. Fixes https://github.com/FabricMC/Enigma/issues/147.

Currently, Enigma can read mappings using both unqualified and qualified inner class names (see [here](https://github.com/FabricMC/Enigma/blob/master/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java#L144) and [here](https://github.com/FabricMC/Enigma/blob/master/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java#L182-L188)), but always saves the qualified name by default. This PR makes Enigma save the unqualified name instead while still being able to read both formats.

The change to intermediaries in yarn seems like a good time to make this change, since obfuscated class names are about to get longer, and the change to intermediaries involves changing every single line in yarn anyway.