### PR TITLE
Add compose, convert, and invert commands

### DIFF
--- a/src/main/java/cuchaz/enigma/CommandMain.java
+++ b/src/main/java/cuchaz/enigma/CommandMain.java
@@ -83,6 +83,8 @@ public class CommandMain {
 		register(new DeobfuscateCommand());
 		register(new DecompileCommand());
 		register(new ConvertMappingsCommand());
+		register(new ComposeMappingsCommand());
+		register(new InvertMappingsCommand());
 		register(new CheckMappingsCommand());
 	}
 

--- a/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
+++ b/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
@@ -1,0 +1,37 @@
+package cuchaz.enigma.command;
+
+import cuchaz.enigma.throwables.MappingParseException;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.utils.Utils;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class ComposeMappingsCommand extends Command {
+    public ComposeMappingsCommand() {
+        super("compose-mappings");
+    }
+
+    @Override
+    public String getUsage() {
+        return "<left-format> <left> <right-format> <right> <result-format> <result> <keep-mode>";
+    }
+
+    @Override
+    public boolean isValidArgument(int length) {
+        return length == 7;
+    }
+
+    @Override
+    public void run(String... args) throws IOException, MappingParseException {
+        EntryTree<EntryMapping> left = MappingCommandsUtil.read(args[0], Paths.get(args[1]));
+        EntryTree<EntryMapping> right = MappingCommandsUtil.read(args[2], Paths.get(args[3]));
+        EntryTree<EntryMapping> result = MappingCommandsUtil.compose(left, right, args[6].equals("left") || args[6].equals("both"), args[6].equals("right") || args[6].equals("both"));
+
+        Path output = Paths.get(args[5]);
+        Utils.delete(output);
+        MappingCommandsUtil.write(result, args[4], output);
+    }
+}

--- a/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
+++ b/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
@@ -9,9 +9,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class ConvertMappingsCommand extends Command {
-    public ConvertMappingsCommand() {
-        super("convert-mappings");
+public class InvertMappingsCommand extends Command {
+    public InvertMappingsCommand() {
+        super("invert-mappings");
     }
 
     @Override
@@ -26,10 +26,11 @@ public class ConvertMappingsCommand extends Command {
 
     @Override
     public void run(String... args) throws IOException, MappingParseException {
-        EntryTree<EntryMapping> mappings = MappingCommandsUtil.read(args[0], Paths.get(args[1]));
+        EntryTree<EntryMapping> source = MappingCommandsUtil.read(args[0], Paths.get(args[1]));
+        EntryTree<EntryMapping> result = MappingCommandsUtil.invert(source);
 
         Path output = Paths.get(args[3]);
         Utils.delete(output);
-        MappingCommandsUtil.write(mappings, args[2], output);
+        MappingCommandsUtil.write(result, args[2], output);
     }
 }

--- a/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
+++ b/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
@@ -1,0 +1,134 @@
+package cuchaz.enigma.command;
+
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.throwables.MappingParseException;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.serde.EnigmaMappingsReader;
+import cuchaz.enigma.translation.mapping.serde.EnigmaMappingsWriter;
+import cuchaz.enigma.translation.mapping.serde.TinyMappingsReader;
+import cuchaz.enigma.translation.mapping.serde.TinyMappingsWriter;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
+import cuchaz.enigma.translation.mapping.tree.HashEntryTree;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+
+public final class MappingCommandsUtil {
+    private MappingCommandsUtil() {}
+
+    @SuppressWarnings("unchecked")
+    public static EntryTree<EntryMapping> invert(EntryTree<EntryMapping> mappings) {
+        EntryTree<EntryMapping> result = new HashEntryTree<>();
+
+        Map<Entry<?>, Entry<?>> rightEntries = new HashMap<>();
+        for (EntryTreeNode<EntryMapping> node : mappings) {
+            Entry<?> leftEntry = node.getEntry();
+            EntryMapping leftMapping = node.getValue();
+
+            if (!(leftEntry instanceof ClassEntry || leftEntry instanceof MethodEntry || leftEntry instanceof FieldEntry)) {
+                result.insert(((Entry<Entry<?>>) leftEntry).withParent(rightEntries.get(leftEntry.getParent())), leftMapping);
+                continue;
+            }
+
+            Entry<?> rightEntry = ((Entry<Entry<?>>) leftEntry)
+                    .withParent(rightEntries.get(leftEntry.getParent()))
+                    .withName(getInnerName(leftMapping == null ? leftEntry.getName() : leftMapping.getTargetName()));
+            rightEntries.put(leftEntry, rightEntry);
+
+            result.insert(rightEntry, leftMapping == null ? null : new EntryMapping(leftEntry.getName())); // TODO: leftMapping.withName once javadoc PR is merged
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static EntryTree<EntryMapping> compose(EntryTree<EntryMapping> left, EntryTree<EntryMapping> right, boolean keepLeftOnly, boolean keepRightOnly) {
+        EntryTree<EntryMapping> result = new HashEntryTree<>();
+        Map<Entry<?>, Entry<?>> leftToRight = new HashMap<>();
+        Map<Entry<?>, Entry<?>> rightToLeft = new HashMap<>();
+        Set<Entry<?>> addedMappings = new HashSet<>();
+
+        for (EntryTreeNode<EntryMapping> node : left) {
+            Entry<?> leftEntry = node.getEntry();
+            EntryMapping leftMapping = node.getValue();
+
+            Entry<?> rightEntry = ((Entry<Entry<?>>) leftEntry)
+                    .withParent(leftToRight.get(leftEntry.getParent()))
+                    .withName(getInnerName(leftMapping == null ? leftEntry.getName() : leftMapping.getTargetName()));
+            leftToRight.put(leftEntry, rightEntry);
+            rightToLeft.put(rightEntry, leftEntry);
+
+            EntryMapping rightMapping = right.get(rightEntry);
+            if (rightMapping != null) {
+                result.insert(leftEntry, rightMapping);
+                addedMappings.add(rightEntry);
+            } else if (keepLeftOnly) {
+                result.insert(leftEntry, leftMapping);
+            }
+        }
+
+        if (keepRightOnly) {
+            for (EntryTreeNode<EntryMapping> node : right) {
+                Entry<?> rightEntry = node.getEntry();
+                EntryMapping rightMapping = node.getValue();
+
+                if (addedMappings.contains(rightEntry)) {
+                    continue;
+                }
+
+                Entry<?> parent = rightEntry.getParent();
+                Entry<?> correctEntry = rightEntry;
+                if (rightToLeft.containsKey(parent)) {
+                    correctEntry = ((Entry<Entry<?>>) rightEntry).withParent(rightToLeft.get(parent));
+                }
+
+                result.insert(correctEntry, rightMapping);
+                rightToLeft.put(rightEntry, correctEntry);
+            }
+        }
+        return result;
+    }
+
+    private static String getInnerName(String name) {
+        int lastDollarSignIndex = name.indexOf('$');
+        return lastDollarSignIndex < 0 ? name : name.substring(lastDollarSignIndex + 1);
+    }
+
+    public static EntryTree<EntryMapping> read(String type, Path path) throws MappingParseException, IOException {
+        if (type.equals("enigma")) {
+            return EnigmaMappingsReader.DIRECTORY.read(path, ProgressListener.none());
+        }
+
+        if (type.equals("tiny")) {
+            return TinyMappingsReader.INSTANCE.read(path, ProgressListener.none());
+        }
+
+        throw new IllegalArgumentException("no reader for " + type);
+    }
+
+    public static void write(EntryTree<EntryMapping> mappings, String type, Path path) {
+        if (type.equals("enigma")) {
+            EnigmaMappingsWriter.DIRECTORY.write(mappings, path, ProgressListener.none());
+            return;
+        }
+
+        if (type.startsWith("tiny")) {
+            String[] split = type.split(":");
+
+            if (split.length != 3) {
+                throw new IllegalArgumentException("specify column names as 'tiny:from_column:to_column'");
+            }
+
+            new TinyMappingsWriter(split[1], split[2]).write(mappings, path, ProgressListener.none());
+            return;
+        }
+
+        throw new IllegalArgumentException("no writer for " + type);
+    }
+}

--- a/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
+++ b/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
@@ -3,10 +3,7 @@ package cuchaz.enigma.command;
 import cuchaz.enigma.ProgressListener;
 import cuchaz.enigma.throwables.MappingParseException;
 import cuchaz.enigma.translation.mapping.EntryMapping;
-import cuchaz.enigma.translation.mapping.serde.EnigmaMappingsReader;
-import cuchaz.enigma.translation.mapping.serde.EnigmaMappingsWriter;
-import cuchaz.enigma.translation.mapping.serde.TinyMappingsReader;
-import cuchaz.enigma.translation.mapping.serde.TinyMappingsWriter;
+import cuchaz.enigma.translation.mapping.serde.*;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
 import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
 import cuchaz.enigma.translation.mapping.tree.HashEntryTree;
@@ -14,6 +11,7 @@ import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.translation.representation.entry.FieldEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import org.checkerframework.checker.units.qual.C;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -109,6 +107,15 @@ public final class MappingCommandsUtil {
             return TinyMappingsReader.INSTANCE.read(path, ProgressListener.none());
         }
 
+        MappingFormat format = null;
+        try {
+            format = MappingFormat.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException ignored) {}
+
+        if (format != null) {
+            return format.getReader().read(path, ProgressListener.none());
+        }
+
         throw new IllegalArgumentException("no reader for " + type);
     }
 
@@ -126,6 +133,16 @@ public final class MappingCommandsUtil {
             }
 
             new TinyMappingsWriter(split[1], split[2]).write(mappings, path, ProgressListener.none());
+            return;
+        }
+
+        MappingFormat format = null;
+        try {
+            format = MappingFormat.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException ignored) {}
+
+        if (format != null) {
+            format.getWriter().write(mappings, path, ProgressListener.none());
             return;
         }
 

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyMappingsWriter.java
@@ -1,0 +1,144 @@
+package cuchaz.enigma.translation.mapping.serde;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.translation.MappingTranslator;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.MappingDelta;
+import cuchaz.enigma.translation.mapping.VoidEntryResolver;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TinyMappingsWriter implements MappingsWriter {
+    private static final String VERSION_CONSTANT = "v1";
+    private static final Joiner TAB_JOINER = Joiner.on('\t');
+
+    // HACK: as of enigma 0.13.1, some fields seem to appear duplicated?
+    private final Set<String> writtenLines = new HashSet<>();
+    private final String nameObf;
+    private final String nameDeobf;
+
+    public TinyMappingsWriter(String nameObf, String nameDeobf) {
+        this.nameObf = nameObf;
+        this.nameDeobf = nameDeobf;
+    }
+
+    @Override
+    public void write(EntryTree<EntryMapping> mappings, MappingDelta<EntryMapping> delta, Path path, ProgressListener progress) {
+        try {
+            Files.deleteIfExists(path);
+            Files.createFile(path);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+            writeLine(writer, new String[]{VERSION_CONSTANT, nameObf, nameDeobf});
+
+            Lists.newArrayList(mappings).stream()
+                    .map(EntryTreeNode::getEntry).sorted(Comparator.comparing(Object::toString))
+                    .forEach(entry -> writeEntry(writer, mappings, entry));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void writeEntry(Writer writer, EntryTree<EntryMapping> mappings, Entry<?> entry) {
+        EntryTreeNode<EntryMapping> node = mappings.findNode(entry);
+        if (node == null) {
+            return;
+        }
+
+        Translator translator = new MappingTranslator(mappings, VoidEntryResolver.INSTANCE);
+
+        EntryMapping mapping = mappings.get(entry);
+        if (mapping != null && !entry.getName().equals(mapping.getTargetName())) {
+            if (entry instanceof ClassEntry) {
+                writeClass(writer, (ClassEntry) entry, translator);
+            } else if (entry instanceof FieldEntry) {
+                writeLine(writer, serializeEntry(entry, mapping.getTargetName()));
+            } else if (entry instanceof MethodEntry) {
+                writeLine(writer, serializeEntry(entry, mapping.getTargetName()));
+            }
+        }
+
+        writeChildren(writer, mappings, node);
+    }
+
+    private void writeChildren(Writer writer, EntryTree<EntryMapping> mappings, EntryTreeNode<EntryMapping> node) {
+        node.getChildren().stream()
+                .filter(e -> e instanceof FieldEntry).sorted()
+                .forEach(child -> writeEntry(writer, mappings, child));
+
+        node.getChildren().stream()
+                .filter(e -> e instanceof MethodEntry).sorted()
+                .forEach(child -> writeEntry(writer, mappings, child));
+
+        node.getChildren().stream()
+                .filter(e -> e instanceof ClassEntry).sorted()
+                .forEach(child -> writeEntry(writer, mappings, child));
+    }
+
+    private void writeClass(Writer writer, ClassEntry entry, Translator translator) {
+        ClassEntry translatedEntry = translator.translate(entry);
+
+        String obfClassName = entry.getFullName();
+        String deobfClassName = translatedEntry.getFullName();
+        writeLine(writer, new String[]{"CLASS", obfClassName, deobfClassName});
+    }
+
+    private void writeLine(Writer writer, String[] data) {
+        try {
+            String line = TAB_JOINER.join(data) + "\n";
+            if (writtenLines.add(line)) {
+                writer.write(line);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String[] serializeEntry(Entry<?> entry, String... extraFields) {
+        String[] data = null;
+
+        if (entry instanceof FieldEntry) {
+            data = new String[4 + extraFields.length];
+            data[0] = "FIELD";
+            data[1] = entry.getContainingClass().getFullName();
+            data[2] = ((FieldEntry) entry).getDesc().toString();
+            data[3] = entry.getName();
+        } else if (entry instanceof MethodEntry) {
+            data = new String[4 + extraFields.length];
+            data[0] = "METHOD";
+            data[1] = entry.getContainingClass().getFullName();
+            data[2] = ((MethodEntry) entry).getDesc().toString();
+            data[3] = entry.getName();
+        } else if (entry instanceof ClassEntry) {
+            data = new String[2 + extraFields.length];
+            data[0] = "CLASS";
+            data[1] = ((ClassEntry) entry).getFullName();
+        }
+
+        if (data != null) {
+            System.arraycopy(extraFields, 0, data, data.length - extraFields.length, extraFields.length);
+        }
+
+        return data;
+    }
+}

--- a/src/main/java/cuchaz/enigma/utils/Utils.java
+++ b/src/main/java/cuchaz/enigma/utils/Utils.java
@@ -16,7 +16,6 @@ import com.google.common.io.CharStreams;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseEvent;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -26,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Utils {
 
@@ -100,11 +100,9 @@ public class Utils {
 
 	public static void delete(Path path) throws IOException {
 		if (path.toFile().exists()) {
-			Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
-		}
-
-		if (path.toFile().exists()) {
-			throw new IOException("failed to delete " + path);
+			for (Path p : Files.walk(path).sorted(Comparator.reverseOrder()).collect(Collectors.toList())) {
+				Files.delete(p);
+			}
 		}
 	}
 }

--- a/src/main/java/cuchaz/enigma/utils/Utils.java
+++ b/src/main/java/cuchaz/enigma/utils/Utils.java
@@ -16,12 +16,15 @@ import com.google.common.io.CharStreams;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseEvent;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Arrays;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 
 public class Utils {
@@ -93,5 +96,15 @@ public class Utils {
 	public static boolean getSystemPropertyAsBoolean(String property, boolean defValue) {
 		String value = System.getProperty(property);
 		return value == null ? defValue : Boolean.parseBoolean(value);
+	}
+
+	public static void delete(Path path) throws IOException {
+		if (path.toFile().exists()) {
+			Files.walk(path).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+		}
+
+		if (path.toFile().exists()) {
+			throw new IOException("failed to delete " + path);
+		}
 	}
 }


### PR DESCRIPTION
The compose command is for remapping the Enigma mappings directory from intermediaries back to Mojang names when building yarn. 

The invert command can be used to create inverted tiny mappings for the initial conversion of yarn mappings to intermediary (since Matcher saving to intermediaries is [currently broken](https://github.com/sfPlayer1/Matcher/issues/5)).

The new convert command now supports writing tiny mappings and can replace weave's tinyify command, fixing https://github.com/FabricMC/weave/issues/2.

Example usage:

- Inverting intermediaries: `invert tiny <intermediaries> tiny:named:official <inverted-intermediaries>`
- Remapping yarn mappings: `compose tiny <(inverted-)intermediaries> enigma <mappings> enigma <remapped-mappings> right` (right means keep mappings on the right that don't have corresponding left mappings, so arguments and mappings for things that don't have intermediaries)
- Tinifying mappings: `convert enigma <remapped-mappings> tiny:official:named <converted>`