### PR TITLE
Fix local variable fixer

### DIFF
--- a/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
@@ -43,12 +43,12 @@ public class LocalVariableFixVisitor extends ClassVisitor {
 			super(api, visitor);
 			this.methodEntry = methodEntry;
 
-			int lvtIndex = methodEntry.getAccess().isStatic() ? 0 : 1;
+			int lvIndex = methodEntry.getAccess().isStatic() ? 0 : 1;
 			List<TypeDescriptor> parameters = methodEntry.getDesc().getArgumentDescs();
 			for (int parameterIndex = 0; parameterIndex < parameters.size(); parameterIndex++) {
 				TypeDescriptor param = parameters.get(parameterIndex);
-				parameterIndices.put(lvtIndex, parameterIndex);
-				lvtIndex += param.getSize();
+				parameterIndices.put(lvIndex, parameterIndex);
+				lvIndex += param.getSize();
 			}
 		}
 

--- a/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
@@ -1,6 +1,7 @@
 package cuchaz.enigma.bytecode.translators;
 
 import com.google.common.base.CharMatcher;
+import cuchaz.enigma.translation.LocalNameGenerator;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
@@ -65,8 +66,8 @@ public class LocalVariableFixVisitor extends ClassVisitor {
 				name = "this";
 			} else if (parameterIndices.containsKey(index)) {
 				name = fixParameterName(parameterIndices.get(index), name);
-			} else if (isInvalidName(name)){
-				name = "var" + index;
+			} else if (isInvalidName(name)) {
+				name = LocalNameGenerator.generateLocalVariableName(index, new TypeDescriptor(desc));
 			}
 
 			super.visitLocalVariable(name, desc, signature, start, end, index);
@@ -94,7 +95,8 @@ public class LocalVariableFixVisitor extends ClassVisitor {
 			}
 
 			if (isInvalidName(name)) {
-				name = "par" + index;
+				List<TypeDescriptor> arguments = methodEntry.getDesc().getArgumentDescs();
+				name = LocalNameGenerator.generateArgumentName(index, arguments.get(index), arguments);
 			}
 
 			if (index == 0 && ownerEntry.getAccess().isEnum() && methodEntry.getName().equals("<init>")) {

--- a/src/main/java/cuchaz/enigma/bytecode/translators/TranslationMethodVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/TranslationMethodVisitor.java
@@ -12,20 +12,20 @@ public class TranslationMethodVisitor extends MethodVisitor {
 	private final Translator translator;
 
 	private int parameterIndex = 0;
-	private int parameterLvtIndex;
+	private int parameterLvIndex;
 
 	public TranslationMethodVisitor(Translator translator, ClassDefEntry ownerEntry, MethodDefEntry methodEntry, int api, MethodVisitor mv) {
 		super(api, mv);
 		this.translator = translator;
 		this.methodEntry = methodEntry;
 
-		parameterLvtIndex = methodEntry.getAccess().isStatic() ? 0 : 1;
+		parameterLvIndex = methodEntry.getAccess().isStatic() ? 0 : 1;
 	}
 
 	@Override
 	public void visitParameter(String name, int access) {
-		name = translateVariableName(parameterLvtIndex, name);
-		parameterLvtIndex += methodEntry.getDesc().getArgumentDescs().get(parameterIndex++).getSize();
+		name = translateVariableName(parameterLvIndex, name);
+		parameterLvIndex += methodEntry.getDesc().getArgumentDescs().get(parameterIndex++).getSize();
 
 		super.visitParameter(name, access);
 	}

--- a/src/main/java/cuchaz/enigma/bytecode/translators/TranslationMethodVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/TranslationMethodVisitor.java
@@ -126,6 +126,7 @@ public class TranslationMethodVisitor extends MethodVisitor {
 	public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
 		signature = translator.translate(Signature.createTypedSignature(signature)).toString();
 		name = translateVariableName(index, name);
+		desc = translator.translate(new TypeDescriptor(desc)).toString();
 
 		super.visitLocalVariable(name, desc, signature, start, end, index);
 	}

--- a/src/main/java/cuchaz/enigma/translation/representation/entry/MethodDefEntry.java
+++ b/src/main/java/cuchaz/enigma/translation/representation/entry/MethodDefEntry.java
@@ -72,20 +72,4 @@ public class MethodDefEntry extends MethodEntry implements DefEntry<ClassEntry> 
 	public MethodDefEntry withParent(ClassEntry parent) {
 		return new MethodDefEntry(new ClassEntry(parent.getFullName()), name, descriptor, signature, access);
 	}
-
-	public int getArgumentIndex(ClassDefEntry ownerEntry, int localVariableIndex) {
-		int argumentIndex = localVariableIndex;
-
-		// Enum constructors have an implicit "name" and "ordinal" parameter as well as "this"
-		if (ownerEntry.getAccess().isEnum() && getName().startsWith("<")) {
-			argumentIndex -= 2;
-		}
-
-		// If we're not static, "this" is bound to index 0
-		if (!getAccess().isStatic()) {
-			argumentIndex -= 1;
-		}
-
-		return argumentIndex;
-	}
 }


### PR DESCRIPTION
A few snapshot ago, Mojang made some changes to the way local variables are obfuscated:
 - Rather than setting all LVT names to `☃️`, it now generates a unique name for each source variable (such as`class_2090_1`). Because the parameter table is now valid, it's no longer ignored by the decompiler, which reveals some bugs in `LocalVariableFixVisitor`. These break jar and source export, but not viewing in Enigma since remapping is done after decompilation.
 -  The `name` and `ordinal` parameters of enum constructors are no longer marked as synthetic, which causes them to not be removed by Procyon. 

This PR
 - Makes `LocalVariableFixVisitor` add `synthetic` flags to the `name` and `ordinal` parameters of enum constructor and set their name to the correct name.
 - Makes `LocalVariableFixVisitor` make sure that LVT entries for parameters have the same name as the parameter.
 - Fixes both `LocalVariableFixVisitor` and `TranslationMethodVisitor` generating the parameter table if the LVT was missing rather than if the parameter table was missing (causing three times as many parameters as there should be for methods without a LVT!).
 - Fixes `TranslationMethodVisitor` not translating parameter entries.
 - Removes variable-fixing logic duplicated in `LocalVariableFixVisitor` and `TranslationMethodVisitor`, simplifying `TranslationMethodVisitor`.
