### PR TITLE
Fix compiling on Java 13

### DIFF
--- a/src/main/java/cuchaz/enigma/analysis/ClassCache.java
+++ b/src/main/java/cuchaz/enigma/analysis/ClassCache.java
@@ -37,7 +37,7 @@ public final class ClassCache implements AutoCloseable, CompiledSource {
 	}
 
 	public static ClassCache of(Path jarPath) throws IOException {
-		FileSystem fileSystem = FileSystems.newFileSystem(jarPath, null);
+		FileSystem fileSystem = FileSystems.newFileSystem(jarPath, (ClassLoader) null);
 		ImmutableSet<String> classNames = collectClassNames(fileSystem);
 
 		return new ClassCache(fileSystem, classNames);


### PR DESCRIPTION
`newFileSystem(Path path, Map<String,?> env)` was added in Java 13, making the call ambiguous.