### PR TITLE
Fix inner class renaming

### DIFF
--- a/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
+++ b/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
@@ -112,7 +112,7 @@ public class PanelEditor extends JEditorPane {
 					Entry<?> entry = reference.getNameableEntry();
 
 					String name = String.valueOf(event.getKeyChar());
-					if (entry instanceof ClassEntry) {
+					if (entry instanceof ClassEntry && ((ClassEntry) entry).getParent() == null) {
 						String packageName = ((ClassEntry) entry).getPackageName();
 						if (packageName != null) {
 							name = packageName + "/" + name;


### PR DESCRIPTION
Can be reproduced when you start typing while your cursor is on the inner class reference token
Signed-off-by: liach <liach@users.noreply.github.com>