### PR TITLE
Correctly decompile bridges, and add command to add specialized methods to mappings

### DIFF
--- a/src/main/java/cuchaz/enigma/CommandMain.java
+++ b/src/main/java/cuchaz/enigma/CommandMain.java
@@ -86,6 +86,7 @@ public class CommandMain {
 		register(new ComposeMappingsCommand());
 		register(new InvertMappingsCommand());
 		register(new CheckMappingsCommand());
+		register(new MapSpecializedMethodsCommand());
 	}
 
 	private static final class CommandHelpException extends IllegalArgumentException {

--- a/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -158,7 +158,7 @@ public class EnigmaProject {
 					ClassNode node = classCache.getClassNode(entry.getFullName());
 					if (node != null) {
 						ClassNode translatedNode = new ClassNode();
-						node.accept(new TranslationClassVisitor(deobfuscator, Opcodes.ASM5, translatedNode));
+						node.accept(new TranslationClassVisitor(deobfuscator, Opcodes.ASM5, new SourceFixVisitor(Opcodes.ASM5, translatedNode, jarIndex)));
 						return translatedNode;
 					}
 
@@ -209,7 +209,6 @@ public class EnigmaProject {
 
 			//create a common instance outside the loop as mappings shouldn't be changing while this is happening
 			CompiledSourceTypeLoader typeLoader = new CompiledSourceTypeLoader(this.compiled::get);
-			typeLoader.addVisitor(visitor -> new SourceFixVisitor(Opcodes.ASM5, visitor, jarIndex));
 
 			//synchronized to make sure the parallelStream doesn't CME with the cache
 			ITypeLoader synchronizedTypeLoader = new SynchronizedTypeLoader(typeLoader);

--- a/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
@@ -4,6 +4,7 @@ import cuchaz.enigma.analysis.index.BridgeMethodIndex;
 import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -30,6 +31,8 @@ public class SourceFixVisitor extends ClassVisitor {
 		BridgeMethodIndex bridgeIndex = index.getBridgeMethodIndex();
 		if (bridgeIndex.isBridgeMethod(methodEntry)) {
 			access |= Opcodes.ACC_BRIDGE;
+		} else if (bridgeIndex.isSpecializedMethod(methodEntry)) {
+			name = bridgeIndex.getBridgeFromSpecialized(methodEntry).getName();
 		}
 
 		return super.visitMethod(access, name, descriptor, signature, exceptions);

--- a/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -1,0 +1,67 @@
+package cuchaz.enigma.command;
+
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.analysis.ClassCache;
+import cuchaz.enigma.analysis.index.BridgeMethodIndex;
+import cuchaz.enigma.analysis.index.JarIndex;
+import cuchaz.enigma.throwables.MappingParseException;
+import cuchaz.enigma.translation.MappingTranslator;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.*;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
+import cuchaz.enigma.translation.mapping.tree.HashEntryTree;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import cuchaz.enigma.utils.Utils;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class MapSpecializedMethodsCommand extends Command {
+    public MapSpecializedMethodsCommand() {
+        super("map-specialized-methods");
+    }
+
+    @Override
+    public String getUsage() {
+        return "<jar> <source-format> <source> <result-format> <result>";
+    }
+
+    @Override
+    public boolean isValidArgument(int length) {
+        return length == 5;
+    }
+
+    @Override
+    public void run(String... args) throws IOException, MappingParseException {
+        MappingSaveParameters saveParameters = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);
+        EntryTree<EntryMapping> source = MappingCommandsUtil.read(args[1], Paths.get(args[2]), saveParameters);
+        EntryTree<EntryMapping> result = new HashEntryTree<>();
+        Path jar = Paths.get(args[0]);
+        ClassCache classCache = ClassCache.of(jar);
+        JarIndex jarIndex = classCache.index(ProgressListener.none());
+        BridgeMethodIndex bridgeMethodIndex = jarIndex.getBridgeMethodIndex();
+        Translator translator = new MappingTranslator(source, jarIndex.getEntryResolver());
+
+        // Copy all non-specialized methods
+        for (EntryTreeNode<EntryMapping> node : source) {
+            if (!(node.getEntry() instanceof MethodEntry) || !bridgeMethodIndex.isSpecializedMethod((MethodEntry) node.getEntry())) {
+                result.insert(node.getEntry(), node.getValue());
+            }
+        }
+
+        // Add correct mappings for specialized methods
+        for (Map.Entry<MethodEntry, MethodEntry> entry : bridgeMethodIndex.getBridgeToSpecialized().entrySet()) {
+            MethodEntry bridge = entry.getKey();
+            MethodEntry specialized = entry.getValue();
+            String name = translator.translate(bridge).getName();
+            result.insert(specialized, new EntryMapping(name));
+        }
+
+        Path output = Paths.get(args[4]);
+        Utils.delete(output);
+        MappingCommandsUtil.write(result, args[3], output, saveParameters);
+    }
+}


### PR DESCRIPTION
The `map-specialized-methods` command should be run by yarn on the built tiny files so that loom (and other remappers) can map them to the correct name. I'll make a yarn PR once this is merged.