### PR TITLE
Allow reading and writing Enigma mappings with javadocs on unnamed identifiers

### DIFF
--- a/src/main/java/cuchaz/enigma/translation/mapping/EntryMapping.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/EntryMapping.java
@@ -4,29 +4,29 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class EntryMapping {
-	private final String targetName;
+	private final @Nullable String targetName;
 	private final AccessModifier accessModifier;
 	private final @Nullable String javadoc;
 
-	public EntryMapping(@Nonnull String targetName) {
+	public EntryMapping(@Nullable String targetName) {
 		this(targetName, AccessModifier.UNCHANGED);
 	}
 
-	public EntryMapping(@Nonnull String targetName, @Nullable String javadoc) {
+	public EntryMapping(@Nullable String targetName, @Nullable String javadoc) {
 		this(targetName, AccessModifier.UNCHANGED, javadoc);
 	}
 
-	public EntryMapping(@Nonnull String targetName, AccessModifier accessModifier) {
+	public EntryMapping(@Nullable String targetName, AccessModifier accessModifier) {
 		this(targetName, accessModifier, null);
 	}
 
-	public EntryMapping(@Nonnull String targetName, AccessModifier accessModifier, @Nullable String javadoc) {
+	public EntryMapping(@Nullable String targetName, AccessModifier accessModifier, @Nullable String javadoc) {
 		this.targetName = targetName;
 		this.accessModifier = accessModifier;
 		this.javadoc = javadoc;
 	}
 
-	@Nonnull
+	@Nullable
 	public String getTargetName() {
 		return targetName;
 	}

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
@@ -157,14 +157,12 @@ public enum EnigmaMappingsReader implements MappingsReader {
 				throw new RuntimeException("Unknown token '" + keyToken + "'");
 		}
 	}
-	
+
 	private void readJavadoc(MappingPair<?, RawEntryMapping> parent, String[] tokens) {
-		if (parent == null)
-			throw new IllegalStateException("Javadoc has no parent!");
+		if (parent == null) throw new IllegalStateException("Javadoc has no parent!");
 		// Empty string to concat
 		String jdLine = tokens.length > 1 ? String.join(" ", Arrays.copyOfRange(tokens,1,tokens.length))  : "";
-		if (parent.getMapping() == null)
-			throw new IllegalStateException("Javadoc requires a mapping!");
+		if (parent.getMapping() == null) throw new IllegalStateException("Javadoc requires a mapping!");
 		parent.getMapping().addJavadocLine(MappingHelper.unescape(jdLine));
 	}
 
@@ -193,11 +191,8 @@ public enum EnigmaMappingsReader implements MappingsReader {
 			modifier = parseModifier(tokens[3]);
 		}
 
-		if (mapping != null) {
-			return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping, modifier));
-		} else {
-			return new MappingPair<>(obfuscatedEntry);
-		}
+		return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping, modifier));
+
 	}
 
 	private MappingPair<FieldEntry, RawEntryMapping> parseField(@Nullable Entry<?> parent, String[] tokens) {
@@ -208,33 +203,38 @@ public enum EnigmaMappingsReader implements MappingsReader {
 		ClassEntry ownerEntry = (ClassEntry) parent;
 
 		String obfuscatedName = tokens[1];
-		String mapping = obfuscatedName;
+		String mapping = null;
 		AccessModifier modifier = AccessModifier.UNCHANGED;
 		TypeDescriptor descriptor;
 
-		if (tokens.length == 4) {
-			AccessModifier parsedModifier = parseModifier(tokens[3]);
-			if (parsedModifier != null) {
+		switch (tokens.length) {
+			case 3: {
 				descriptor = new TypeDescriptor(tokens[2]);
-				modifier = parsedModifier;
-			} else {
-				mapping = tokens[2];
-				descriptor = new TypeDescriptor(tokens[3]);
+				break;
 			}
-		} else if (tokens.length == 5) {
-			descriptor = new TypeDescriptor(tokens[3]);
-			mapping = tokens[2];
-			modifier = parseModifier(tokens[4]);
-		} else {
-			throw new RuntimeException("Invalid field declaration");
+			case 4: {
+				AccessModifier parsedModifier = parseModifier(tokens[3]);
+				if (parsedModifier != null) {
+					descriptor = new TypeDescriptor(tokens[2]);
+					modifier = parsedModifier;
+				} else {
+					mapping = tokens[2];
+					descriptor = new TypeDescriptor(tokens[3]);
+				}
+				break;
+		    }
+			case 5: {
+				descriptor = new TypeDescriptor(tokens[3]);
+				mapping = tokens[2];
+				modifier = parseModifier(tokens[4]);
+				break;
+			}
+			default:
+				throw new RuntimeException("Invalid field declaration");
 		}
 
 		FieldEntry obfuscatedEntry = new FieldEntry(ownerEntry, obfuscatedName, descriptor);
-		if (mapping != null) {
-			return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping, modifier));
-		} else {
-			return new MappingPair<>(obfuscatedEntry);
-		}
+		return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping, modifier));
 	}
 
 	private MappingPair<MethodEntry, RawEntryMapping> parseMethod(@Nullable Entry<?> parent, String[] tokens) {
@@ -270,11 +270,8 @@ public enum EnigmaMappingsReader implements MappingsReader {
 		}
 
 		MethodEntry obfuscatedEntry = new MethodEntry(ownerEntry, obfuscatedName, descriptor);
-		if (mapping != null) {
-			return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping, modifier));
-		} else {
-			return new MappingPair<>(obfuscatedEntry);
-		}
+		return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping, modifier));
+
 	}
 
 	private MappingPair<LocalVariableEntry, RawEntryMapping> parseArgument(@Nullable Entry<?> parent, String[] tokens) {

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
@@ -281,7 +281,8 @@ public enum EnigmaMappingsReader implements MappingsReader {
 
 		MethodEntry ownerEntry = (MethodEntry) parent;
 		LocalVariableEntry obfuscatedEntry = new LocalVariableEntry(ownerEntry, Integer.parseInt(tokens[1]), "", true, null);
-		String mapping = tokens[2];
+		String mapping = null;
+		if(tokens.length >= 3) mapping = tokens[2];
 
 		return new MappingPair<>(obfuscatedEntry, new RawEntryMapping(mapping));
 	}

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
@@ -47,8 +47,8 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 		@Override
 		public void write(EntryTree<EntryMapping> mappings, MappingDelta<EntryMapping> delta, Path path, ProgressListener progress, MappingSaveParameters saveParameters) {
 			Collection<ClassEntry> classes = mappings.getRootNodes()
-					.filter(entry -> entry instanceof ClassEntry)
-					.map(entry -> (ClassEntry) entry)
+					.filter(entry -> entry.getEntry() instanceof ClassEntry)
+					.map(entry -> (ClassEntry) entry.getEntry())
 					.collect(Collectors.toList());
 
 			progress.init(classes.size(), "Writing classes");
@@ -275,7 +275,7 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 	}
 
 	private void writeMapping(StringBuilder builder, EntryMapping mapping) {
-		if (mapping != null) {
+		if (mapping != null && mapping.getTargetName() != null) {
 			builder.append(mapping.getTargetName()).append(' ');
 			if (mapping.getAccessModifier() != AccessModifier.UNCHANGED) {
 				builder.append(mapping.getAccessModifier().getFormattedName()).append(' ');

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/RawEntryMapping.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/RawEntryMapping.java
@@ -6,16 +6,18 @@ import cuchaz.enigma.translation.mapping.EntryMapping;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 final class RawEntryMapping {
-	private final String targetName;
+	private final @Nullable String targetName;
 	private final AccessModifier access;
 	private List<String> javadocs = new ArrayList<>();
 
-	RawEntryMapping(String targetName) {
+	RawEntryMapping(@Nullable String targetName) {
 		this(targetName, null);
 	}
 
-	RawEntryMapping(String targetName, AccessModifier access) {
+	RawEntryMapping(@Nullable String targetName, AccessModifier access) {
 		this.access = access;
 		this.targetName = targetName;
 	}

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyV2Writer.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyV2Writer.java
@@ -101,9 +101,9 @@ public final class TinyV2Writer implements MappingsWriter {
 			writer.println(node.getEntry().getName()); // todo fix v2 name inference
 		} else {
 			writer.println(mapping.getTargetName());
-
-			writeComment(writer, mapping, 2);
 		}
+
+		writeComment(writer, mapping, 2);
 
 		for (EntryTreeNode<EntryMapping> child : node.getChildNodes()) {
 			Entry entry = child.getEntry();
@@ -129,9 +129,9 @@ public final class TinyV2Writer implements MappingsWriter {
 			writer.println(node.getEntry().getName()); // todo fix v2 name inference
 		} else {
 			writer.println(mapping.getTargetName());
-
-			writeComment(writer, mapping, 2);
 		}
+
+		writeComment(writer, mapping, 2);
 	}
 
 	private void writeParameter(PrintWriter writer, EntryTreeNode<EntryMapping> node) {
@@ -145,13 +145,13 @@ public final class TinyV2Writer implements MappingsWriter {
 		writer.print(node.getEntry().getName());
 		writer.print("\t");
 		EntryMapping mapping = node.getValue();
-		if (mapping == null) {
+		if (mapping == null || mapping.getTargetName() == null) {
 			writer.println(); // todo ???
 		} else {
 			writer.println(mapping.getTargetName());
-
-			writeComment(writer, mapping, 3);
 		}
+
+		writeComment(writer, mapping, 3);
 	}
 
 	private void writeComment(PrintWriter writer, EntryMapping mapping, int indent) {

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyV2Writer.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyV2Writer.java
@@ -61,7 +61,7 @@ public final class TinyV2Writer implements MappingsWriter {
 		Deque<String> parts = new LinkedList<>();
 		do {
 			EntryMapping mapping = tree.get(classEntry);
-			if (mapping != null) {
+			if (mapping != null && mapping.getTargetName() != null) {
 				parts.addFirst(mapping.getTargetName());
 			} else {
 				parts.addFirst(classEntry.getName());
@@ -97,7 +97,7 @@ public final class TinyV2Writer implements MappingsWriter {
 		writer.print(node.getEntry().getName());
 		writer.print("\t");
 		EntryMapping mapping = node.getValue();
-		if (mapping == null) {
+		if (mapping == null || mapping.getTargetName() == null) {
 			writer.println(node.getEntry().getName()); // todo fix v2 name inference
 		} else {
 			writer.println(mapping.getTargetName());
@@ -125,7 +125,7 @@ public final class TinyV2Writer implements MappingsWriter {
 		writer.print(node.getEntry().getName());
 		writer.print("\t");
 		EntryMapping mapping = node.getValue();
-		if (mapping == null) {
+		if (mapping == null || mapping.getTargetName() == null) {
 			writer.println(node.getEntry().getName()); // todo fix v2 name inference
 		} else {
 			writer.println(mapping.getTargetName());

--- a/src/test/java/cuchaz/enigma/mapping/TestTinyV2InnerClasses.java
+++ b/src/test/java/cuchaz/enigma/mapping/TestTinyV2InnerClasses.java
@@ -32,7 +32,7 @@ public final class TestTinyV2InnerClasses {
 		mappings = Paths.get(TestTinyV2InnerClasses.class.getResource("/tinyV2InnerClasses/").toURI());
 	}
 
-//	@Test
+	@Test
 	public void testMappings() throws Exception {
 		EnigmaProject project = Enigma.create().openJar(jar, ProgressListener.none());
 		project.setMappings(EnigmaMappingsReader.DIRECTORY.read(mappings, ProgressListener.none(), project.getEnigma().getProfile().getMappingSaveParameters()));

--- a/src/test/java/cuchaz/enigma/mapping/TestUnnamedMappings.java
+++ b/src/test/java/cuchaz/enigma/mapping/TestUnnamedMappings.java
@@ -1,0 +1,55 @@
+package cuchaz.enigma.mapping;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.throwables.MappingParseException;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.MappingFileNameFormat;
+import cuchaz.enigma.translation.mapping.MappingSaveParameters;
+import cuchaz.enigma.translation.mapping.serde.EnigmaMappingsReader;
+import cuchaz.enigma.translation.mapping.serde.EnigmaMappingsWriter;
+import cuchaz.enigma.translation.mapping.serde.TinyV2Writer;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestUnnamedMappings {
+	private static Path DIRECTORY;
+
+	static {
+		try {
+			DIRECTORY = Paths.get(TestTinyV2InnerClasses.class.getResource("/emptyfield/").toURI());
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Test
+	public void testParseAndWrite() throws IOException, MappingParseException {
+		ProgressListener progressListener = ProgressListener.none();
+		MappingSaveParameters params = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);
+		EntryTree<EntryMapping> mappings = EnigmaMappingsReader.DIRECTORY.read(DIRECTORY, progressListener, params);
+
+		Path writtenDir = DIRECTORY.getParent().resolve("written");
+		Files.createDirectories(writtenDir);
+		EnigmaMappingsWriter.FILE.write(mappings, writtenDir.resolve("written.mapping"), progressListener, params);
+	}
+
+	@Test
+	public void testParseAndConvert() throws IOException, MappingParseException {
+		ProgressListener progressListener = ProgressListener.none();
+		MappingSaveParameters params = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);
+		EntryTree<EntryMapping> mappings = EnigmaMappingsReader.DIRECTORY.read(DIRECTORY, progressListener, params);
+
+		Path writtenDir = DIRECTORY.getParent().resolve("written");
+		Files.createDirectories(writtenDir);
+		new TinyV2Writer("intermediary", "named")
+						.write(mappings, DIRECTORY.resolve("convertedtiny.tiny"), progressListener, params);
+
+	}
+}

--- a/src/test/resources/emptyfield/UnnamedField.mapping
+++ b/src/test/resources/emptyfield/UnnamedField.mapping
@@ -3,5 +3,7 @@ CLASS UnnamedField foo
 		COMMENT comment on unnamed field
 	METHOD method_2345 (I)V
 		COMMENT comment on unnamed method
+		ARG 1
+			COMMENT comment on unnamed parameter
 	CLASS class_3456
 		COMMENT comment on unnamed class

--- a/src/test/resources/emptyfield/UnnamedField.mapping
+++ b/src/test/resources/emptyfield/UnnamedField.mapping
@@ -1,0 +1,4 @@
+CLASS UnnamedField foo
+	FIELD field_1234 Lnet/minecraft/class_1158;
+		COMMENT comment on unnamed field
+		

--- a/src/test/resources/emptyfield/UnnamedField.mapping
+++ b/src/test/resources/emptyfield/UnnamedField.mapping
@@ -1,4 +1,7 @@
 CLASS UnnamedField foo
 	FIELD field_1234 Lnet/minecraft/class_1158;
 		COMMENT comment on unnamed field
-		
+	METHOD method_2345 (I)V
+		COMMENT comment on unnamed method
+	CLASS class_3456
+		COMMENT comment on unnamed class


### PR DESCRIPTION
This is to make it so Enigma doesn't freak out when Cloak outputs javadocs on unnamed identifiers at some point.
Example of such mappings are in  `src/test/resources/emptyfield/UnnamedField.mapping`.