### PR TITLE
Fix division by zero

### DIFF
--- a/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
+++ b/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
@@ -97,7 +97,8 @@ public class ReferenceIndex implements JarIndexer {
 	}
 
 	private <K extends Entry<?>, V extends Entry<?>> Multimap<K, V> remapReferences(JarIndex index, Multimap<K, V> multimap) {
-		Multimap<K, V> resolved = HashMultimap.create(multimap.keySet().size(), multimap.size() / multimap.keySet().size());
+		final int keySetSize = multimap.keySet().size();
+		Multimap<K, V> resolved = HashMultimap.create(multimap.keySet().size(), keySetSize == 0 ? 0 : multimap.size() / keySetSize);
 		for (Map.Entry<K, V> entry : multimap.entries()) {
 			resolved.put(remap(index, entry.getKey()), remap(index, entry.getValue()));
 		}


### PR DESCRIPTION
This appears to have been missed by an earlier commit that fixed this for the method below. It was biting me, so I fixed it.