### PR TITLE
Add support for reading/writing zipped mappings

### DIFF
--- a/src/main/java/cuchaz/enigma/Main.java
+++ b/src/main/java/cuchaz/enigma/Main.java
@@ -25,6 +25,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.google.common.io.MoreFiles;
+
 public class Main {
 
 	public static void main(String[] args) throws IOException {
@@ -78,6 +80,8 @@ public class Main {
 								Path mappingsPath = options.valueOf(mappings);
 								if (Files.isDirectory(mappingsPath)) {
 									controller.openMappings(MappingFormat.ENIGMA_DIRECTORY, mappingsPath);
+								} else if ("zip".equalsIgnoreCase(MoreFiles.getFileExtension(mappingsPath))) {
+									controller.openMappings(MappingFormat.ENIGMA_ZIP, mappingsPath);
 								} else {
 									controller.openMappings(MappingFormat.ENIGMA_FILE, mappingsPath);
 								}

--- a/src/main/java/cuchaz/enigma/command/Command.java
+++ b/src/main/java/cuchaz/enigma/command/Command.java
@@ -13,6 +13,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.google.common.io.MoreFiles;
+
 public abstract class Command {
 	public final String name;
 
@@ -49,6 +51,8 @@ public abstract class Command {
 	protected static MappingFormat chooseEnigmaFormat(Path path) {
 		if (Files.isDirectory(path)) {
 			return MappingFormat.ENIGMA_DIRECTORY;
+		} else if ("zip".equalsIgnoreCase(MoreFiles.getFileExtension(path))) {
+			return MappingFormat.ENIGMA_ZIP;
 		} else {
 			return MappingFormat.ENIGMA_FILE;
 		}

--- a/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -39,7 +39,7 @@ public class MapSpecializedMethodsCommand extends Command {
         run(Paths.get(args[0]), args[1], Paths.get(args[2]), args[3], Paths.get(args[4]));
     }
 
-    public void run(Path jar, String sourceFormat, Path sourcePath, String resultFormat, Path output) throws IOException, MappingParseException {
+    public static void run(Path jar, String sourceFormat, Path sourcePath, String resultFormat, Path output) throws IOException, MappingParseException {
         MappingSaveParameters saveParameters = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);
         EntryTree<EntryMapping> source = MappingCommandsUtil.read(sourceFormat, sourcePath, saveParameters);
         EntryTree<EntryMapping> result = new HashEntryTree<>();

--- a/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -36,10 +36,13 @@ public class MapSpecializedMethodsCommand extends Command {
 
     @Override
     public void run(String... args) throws IOException, MappingParseException {
+        run(Paths.get(args[0]), args[1], Paths.get(args[2]), args[3], Paths.get(args[4]));
+	}
+
+	public void run(Path jar, String sourceFormat, Path sourcePath, String resultFormat, Path output) throws IOException, MappingParseException {
         MappingSaveParameters saveParameters = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);
-        EntryTree<EntryMapping> source = MappingCommandsUtil.read(args[1], Paths.get(args[2]), saveParameters);
+        EntryTree<EntryMapping> source = MappingCommandsUtil.read(sourceFormat, sourcePath, saveParameters);
         EntryTree<EntryMapping> result = new HashEntryTree<>();
-        Path jar = Paths.get(args[0]);
         ClassCache classCache = ClassCache.of(jar);
         JarIndex jarIndex = classCache.index(ProgressListener.none());
         BridgeMethodIndex bridgeMethodIndex = jarIndex.getBridgeMethodIndex();
@@ -60,8 +63,7 @@ public class MapSpecializedMethodsCommand extends Command {
             result.insert(specialized, new EntryMapping(name));
         }
 
-        Path output = Paths.get(args[4]);
         Utils.delete(output);
-        MappingCommandsUtil.write(result, args[3], output, saveParameters);
+        MappingCommandsUtil.write(result, resultFormat, output, saveParameters);
     }
 }

--- a/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -37,9 +37,9 @@ public class MapSpecializedMethodsCommand extends Command {
     @Override
     public void run(String... args) throws IOException, MappingParseException {
         run(Paths.get(args[0]), args[1], Paths.get(args[2]), args[3], Paths.get(args[4]));
-	}
+    }
 
-	public void run(Path jar, String sourceFormat, Path sourcePath, String resultFormat, Path output) throws IOException, MappingParseException {
+    public void run(Path jar, String sourceFormat, Path sourcePath, String resultFormat, Path output) throws IOException, MappingParseException {
         MappingSaveParameters saveParameters = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);
         EntryTree<EntryMapping> source = MappingCommandsUtil.read(sourceFormat, sourcePath, saveParameters);
         EntryTree<EntryMapping> result = new HashEntryTree<>();

--- a/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
+++ b/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
@@ -17,6 +17,7 @@ import cuchaz.enigma.translation.representation.entry.FieldEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
@@ -81,7 +82,7 @@ public final class MappingCommandsUtil {
 
     public static EntryTree<EntryMapping> read(String type, Path path, MappingSaveParameters saveParameters) throws MappingParseException, IOException {
         if (type.equals("enigma")) {
-            return EnigmaMappingsReader.DIRECTORY.read(path, ProgressListener.none(), saveParameters);
+            return (Files.isDirectory(path) ? EnigmaMappingsReader.DIRECTORY : EnigmaMappingsReader.ZIP).read(path, ProgressListener.none(), saveParameters);
         }
 
         if (type.equals("tiny")) {

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
@@ -16,6 +16,8 @@ import cuchaz.enigma.utils.I18n;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
@@ -61,6 +63,14 @@ public enum EnigmaMappingsReader implements MappingsReader {
 			}
 
 			return mappings;
+		}
+	},
+	ZIP {
+		@Override
+		public EntryTree<EntryMapping> read(Path zip, ProgressListener progress, MappingSaveParameters saveParameters) throws MappingParseException, IOException {
+			try (FileSystem fs = FileSystems.newFileSystem(zip, (ClassLoader) null)) {
+				return DIRECTORY.read(fs.getPath("/"), progress, saveParameters);
+			}
 		}
 	};
 

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
@@ -168,13 +168,13 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 	ZIP {
 		@Override
 		public void write(EntryTree<EntryMapping> mappings, MappingDelta<EntryMapping> delta, Path zip, ProgressListener progress, MappingSaveParameters saveParameters) {
-	        try (FileSystem fs = FileSystems.newFileSystem(new URI("jar:file", null, zip.toUri().getPath(), ""), Collections.singletonMap("create", "true"))) {
-	        	DIRECTORY.write(mappings, delta, fs.getPath("/"), progress, saveParameters);
-	        } catch (IOException e) {
+			try (FileSystem fs = FileSystems.newFileSystem(new URI("jar:file", null, zip.toUri().getPath(), ""), Collections.singletonMap("create", "true"))) {
+				DIRECTORY.write(mappings, delta, fs.getPath("/"), progress, saveParameters);
+			} catch (IOException e) {
 				e.printStackTrace();
 			} catch (URISyntaxException e) {
-	            throw new RuntimeException("Unexpected error creating URI for " + zip, e);
-	        }
+				throw new RuntimeException("Unexpected error creating URI for " + zip, e);
+			}
 		}
 	};
 

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
@@ -13,12 +13,17 @@ package cuchaz.enigma.translation.mapping.serde;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -158,6 +163,18 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 
 		private Path resolve(Path root, ClassEntry classEntry) {
 			return root.resolve(classEntry.getFullName() + ".mapping");
+		}
+	},
+	ZIP {
+		@Override
+		public void write(EntryTree<EntryMapping> mappings, MappingDelta<EntryMapping> delta, Path zip, ProgressListener progress, MappingSaveParameters saveParameters) {
+	        try (FileSystem fs = FileSystems.newFileSystem(new URI("jar:file", null, zip.toUri().getPath(), ""), Collections.singletonMap("create", "true"))) {
+	        	DIRECTORY.write(mappings, delta, fs.getPath("/"), progress, saveParameters);
+	        } catch (IOException e) {
+				e.printStackTrace();
+			} catch (URISyntaxException e) {
+	            throw new RuntimeException("Unexpected error creating URI for " + zip, e);
+	        }
 		}
 	};
 

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 public enum MappingFormat {
 	ENIGMA_FILE(EnigmaMappingsWriter.FILE, EnigmaMappingsReader.FILE),
 	ENIGMA_DIRECTORY(EnigmaMappingsWriter.DIRECTORY, EnigmaMappingsReader.DIRECTORY),
+	ENIGMA_ZIP(EnigmaMappingsWriter.ZIP, EnigmaMappingsReader.ZIP),
 	TINY_V2(new TinyV2Writer("intermediary", "named"), new TinyV2Reader()),
 	TINY_FILE(TinyMappingsWriter.INSTANCE, TinyMappingsReader.INSTANCE),
 	SRG_FILE(SrgMappingsWriter.INSTANCE, null),

--- a/src/main/java/cuchaz/enigma/utils/Utils.java
+++ b/src/main/java/cuchaz/enigma/utils/Utils.java
@@ -101,7 +101,7 @@ public class Utils {
 	}
 
 	public static void delete(Path path) throws IOException {
-		if (path.toFile().exists()) {
+		if (Files.exists(path)) {
 			for (Path p : Files.walk(path).sorted(Comparator.reverseOrder()).collect(Collectors.toList())) {
 				Files.delete(p);
 			}

--- a/src/main/resources/lang/en_us.json
+++ b/src/main/resources/lang/en_us.json
@@ -3,6 +3,7 @@
 
 	"mapping_format.enigma_file": "Enigma File",
 	"mapping_format.enigma_directory": "Enigma Directory",
+	"mapping_format.enigma_zip": "Enigma ZIP",
 	"mapping_format.tiny_v2": "Tiny v2",
 	"mapping_format.tiny_file": "Tiny File",
 	"mapping_format.srg_file": "SRG File",


### PR DESCRIPTION
Takes paths which are ZIP files as zipped mappings rather than trying to read it as a directory or mapping file. Passing in a `Path` directly from a ZIP file system will be read correctly where it is possible to do so.