### PR TITLE
Fix documenting constructors

### DIFF
--- a/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -547,7 +547,7 @@ public class GuiController {
 	}
 
 	public void changeDocs(EntryReference<Entry<?>, Entry<?>> reference, String updatedDocs) {
-		changeDoc(reference.getNameableEntry(), updatedDocs);
+		changeDoc(reference.entry, updatedDocs);
 
 		refreshCurrentClass(reference, RefreshMode.JAVADOCS);
 	}


### PR DESCRIPTION
Fixes #200.

`EntryReference.getNameableEntry()` specifically excludes constructors (and does nothing else), so I switched it to always use the entry field.