### PR TITLE
Fix CFR-related bugs

### DIFF
--- a/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
+++ b/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
@@ -82,7 +82,7 @@ public class EnigmaDumper implements Dumper {
     }
 
     private MethodEntry getMethodEntry(MethodPrototype method) {
-        if (method.getClassType() == null) {
+        if (method == null || method.getClassType() == null) {
             return null;
         }
 
@@ -97,7 +97,7 @@ public class EnigmaDumper implements Dumper {
     private LocalVariableEntry getParameterEntry(MethodPrototype method, int parameterIndex, String name) {
         int variableIndex = method.isInstanceMethod() ? 1 : 0;
         for (int i = 0; i < parameterIndex; i++) {
-            variableIndex += method.getArgs().get(parameterIndex).getStackType().getComputationCategory();
+            variableIndex += method.getArgs().get(i).getStackType().getComputationCategory();
         }
 
         return new LocalVariableEntry(getMethodEntry(method), variableIndex, name, true, null);

--- a/src/main/java/cuchaz/enigma/source/procyon/index/TokenFactory.java
+++ b/src/main/java/cuchaz/enigma/source/procyon/index/TokenFactory.java
@@ -17,6 +17,11 @@ public class TokenFactory {
         String name = node instanceof Identifier ? ((Identifier) node).getName() : "";
         Region region = node.getRegion();
 
+        if (region.getBeginLine() == 0) {
+            System.err.println("Got bad region from Procyon for node " + node);
+            return null;
+        }
+
         int start = index.getPosition(region.getBeginLine(), region.getBeginColumn());
         int end = index.getPosition(region.getEndLine(), region.getEndColumn());
         String text = index.getSource().substring(start, end);


### PR DESCRIPTION
 - Fixes crash with Procyon when a node has a bad region (accidentally removed the check in my last PR)
 - Fixes CFR parameter indices being incorrect when method contains longs and doubles
 - Fixes crash with CFR for classes with method references