### PR TITLE
Convert javadoc escape codes into raw characters when loading Tiny v2 mappings

### DIFF
--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyV2Reader.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/TinyV2Reader.java
@@ -239,7 +239,7 @@ final class TinyV2Reader implements MappingsReader {
 		if (mapping == null) {
 			throw new IllegalArgumentException("Javadoc requires a mapping in enigma!");
 		}
-		mapping.addJavadocLine(javadoc);
+		mapping.addJavadocLine(unescape(javadoc));
 	}
 
 


### PR DESCRIPTION
Currently, line breaks in Tiny v2 javadoc comments transform into `\\n` when converted to Enigma mappings, which will be `\n` in the comments in the decompiled code.

An `unescape` call fixes this since writing will escape it again (but only once instead of twice).