### PR TITLE
QOL fixes

### DIFF
--- a/src/main/java/cuchaz/enigma/Enigma.java
+++ b/src/main/java/cuchaz/enigma/Enigma.java
@@ -12,10 +12,7 @@
 package cuchaz.enigma;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import cuchaz.enigma.analysis.ClassCache;
 import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.api.EnigmaPlugin;
@@ -27,10 +24,7 @@ import cuchaz.enigma.api.service.JarIndexerService;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.ServiceLoader;
 
 public class Enigma {

--- a/src/main/java/cuchaz/enigma/EnigmaServices.java
+++ b/src/main/java/cuchaz/enigma/EnigmaServices.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableListMultimap;
 import cuchaz.enigma.api.service.EnigmaService;
 import cuchaz.enigma.api.service.EnigmaServiceType;
 
-import java.util.Collections;
 import java.util.List;
 
 public final class EnigmaServices {

--- a/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
@@ -4,7 +4,6 @@ import cuchaz.enigma.analysis.index.BridgeMethodIndex;
 import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
-import cuchaz.enigma.translation.representation.entry.MethodEntry;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;

--- a/src/main/java/cuchaz/enigma/bytecode/translators/TranslationSignatureVisitor.java
+++ b/src/main/java/cuchaz/enigma/bytecode/translators/TranslationSignatureVisitor.java
@@ -1,7 +1,6 @@
 package cuchaz.enigma.bytecode.translators;
 
 import cuchaz.enigma.utils.Utils;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.signature.SignatureVisitor;
 
 import java.util.Stack;

--- a/src/main/java/cuchaz/enigma/gui/DecompiledClassSource.java
+++ b/src/main/java/cuchaz/enigma/gui/DecompiledClassSource.java
@@ -6,7 +6,6 @@ import cuchaz.enigma.analysis.EntryReference;
 import cuchaz.enigma.analysis.Token;
 import cuchaz.enigma.api.service.NameProposalService;
 import cuchaz.enigma.gui.highlight.TokenHighlightType;
-import cuchaz.enigma.source.Decompiler;
 import cuchaz.enigma.source.SourceIndex;
 import cuchaz.enigma.translation.LocalNameGenerator;
 import cuchaz.enigma.translation.Translator;

--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -49,7 +49,6 @@ import java.awt.event.*;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class Gui {
@@ -501,7 +500,7 @@ public class Gui {
 		container.add(panel);
 	}
 
-	private JComboBox<AccessModifier> addModifierComboBox(JPanel container, String name, Entry entry) {
+	private JComboBox<AccessModifier> addModifierComboBox(JPanel container, String name, Entry<?> entry) {
 		if (!getController().project.isRenamable(entry))
 			return null;
 		JPanel panel = new JPanel();

--- a/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -37,7 +37,6 @@ import cuchaz.enigma.translation.representation.entry.MethodEntry;
 import cuchaz.enigma.utils.I18n;
 import cuchaz.enigma.utils.ReadableToken;
 import cuchaz.enigma.utils.Utils;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.ClassNode;
 
 import javax.annotation.Nullable;
@@ -532,8 +531,10 @@ public class GuiController {
 		Entry<?> entry = reference.getNameableEntry();
 		project.getMapper().mapFromObf(entry, new EntryMapping(newName));
 
-		if (refreshClassTree && reference.entry instanceof ClassEntry && !((ClassEntry) reference.entry).isInnerClass())
+		if (refreshClassTree && reference.entry instanceof ClassEntry && !((ClassEntry) reference.entry).isInnerClass()) {
 			this.gui.moveClassTree(reference, newName);
+			this.markAsDeobfuscated(reference);
+		}
 
 		refreshCurrentClass(reference);
 	}

--- a/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -531,10 +531,8 @@ public class GuiController {
 		Entry<?> entry = reference.getNameableEntry();
 		project.getMapper().mapFromObf(entry, new EntryMapping(newName));
 
-		if (refreshClassTree && reference.entry instanceof ClassEntry && !((ClassEntry) reference.entry).isInnerClass()) {
+		if (refreshClassTree && reference.entry instanceof ClassEntry && !((ClassEntry) reference.entry).isInnerClass())
 			this.gui.moveClassTree(reference, newName);
-			this.markAsDeobfuscated(reference);
-		}
 
 		refreshCurrentClass(reference);
 	}

--- a/src/main/java/cuchaz/enigma/gui/dialog/CrashDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/CrashDialog.java
@@ -83,7 +83,7 @@ public class CrashDialog {
 		// show the frame
 		frame.setSize(600, 400);
 		frame.setLocationRelativeTo(parent);
-		frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+		frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 	}
 
 	public static void init(JFrame parent) {

--- a/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -74,7 +74,7 @@ public class JavadocDialog {
 		// show the frame
 		frame.setSize(600, 400);
 		frame.setLocationRelativeTo(parent);
-		frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+		frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 	}
 
 	public static void init(JFrame parent, JTextArea area, Callback callback) {

--- a/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
+++ b/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
@@ -8,7 +8,6 @@ import cuchaz.enigma.gui.dialog.SearchDialog;
 import cuchaz.enigma.gui.stats.StatsMember;
 import cuchaz.enigma.translation.mapping.serde.MappingFormat;
 import cuchaz.enigma.utils.I18n;
-import cuchaz.enigma.utils.Utils;
 
 import javax.swing.*;
 import java.awt.*;
@@ -40,6 +39,9 @@ public class MenuBar extends JMenuBar {
 	public MenuBar(Gui gui) {
 		this.gui = gui;
 
+		/*
+		 * File menu
+		 */
 		{
 			JMenu menu = new JMenu(I18n.translate("menu.file"));
 			this.add(menu);
@@ -48,9 +50,14 @@ public class MenuBar extends JMenuBar {
 				menu.add(item);
 				item.addActionListener(event -> {
 					this.gui.jarFileChooser.setVisible(true);
-					Path path = Paths.get(this.gui.jarFileChooser.getDirectory()).resolve(this.gui.jarFileChooser.getFile());
-					if (Files.exists(path)) {
-						gui.getController().openJar(path);
+					String file = this.gui.jarFileChooser.getFile();
+					// checks if the file name is not empty
+					if (file != null) {
+						Path path = Paths.get(this.gui.jarFileChooser.getDirectory()).resolve(file);
+						// checks if the file name corresponds to an existing file
+						if (Files.exists(path)) {
+							gui.getController().openJar(path);
+						}
 					}
 				});
 			}
@@ -189,6 +196,7 @@ public class MenuBar extends JMenuBar {
 
 					pane.add(button);
                     frame.pack();
+                    frame.setLocationRelativeTo(this.gui.getFrame());
                     frame.setVisible(true);
                 });
 
@@ -202,6 +210,9 @@ public class MenuBar extends JMenuBar {
 			}
 		}
 
+		/*
+		 * Decompiler menu
+		 */
 		{
 			JMenu menu = new JMenu(I18n.translate("menu.decompiler"));
 			add(menu);
@@ -222,6 +233,9 @@ public class MenuBar extends JMenuBar {
 			}
 		}
 
+		/*
+		 * View menu
+		 */
 		{
 			JMenu menu = new JMenu(I18n.translate("menu.view"));
 			this.add(menu);
@@ -250,16 +264,12 @@ public class MenuBar extends JMenuBar {
 						pane.add(text);
 						
 						JButton okButton = new JButton(I18n.translate("menu.view.languages.ok"));
-						okButton.setAlignmentX(JButton.CENTER_ALIGNMENT);
-						okButton.setHorizontalAlignment(JButton.CENTER);
 						pane.add(okButton);
 						okButton.addActionListener(arg0 -> frame.dispose());
 						
-						frame.setSize(350, 110);
-						frame.setResizable(false);
+						frame.pack();
 						frame.setLocationRelativeTo(this.gui.getFrame());
 						frame.setVisible(true);
-						frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 					});
 				}
 
@@ -274,6 +284,10 @@ public class MenuBar extends JMenuBar {
 
 			}
 		}
+		
+		/*
+		 * Help menu
+		 */
 		{
 			JMenu menu = new JMenu(I18n.translate("menu.help"));
 			this.add(menu);

--- a/src/main/java/cuchaz/enigma/gui/elements/PopupMenuBar.java
+++ b/src/main/java/cuchaz/enigma/gui/elements/PopupMenuBar.java
@@ -24,7 +24,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.rename"));
 			menu.addActionListener(event -> gui.startRename());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.renameMenu = menu;
@@ -32,7 +32,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.javadoc"));
 			menu.addActionListener(event -> gui.startDocChange());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.editJavadocMenu = menu;
@@ -40,7 +40,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.inheritance"));
 			menu.addActionListener(event -> gui.showInheritance());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showInheritanceMenu = menu;
@@ -48,7 +48,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.implementations"));
 			menu.addActionListener(event -> gui.showImplementations());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showImplementationsMenu = menu;
@@ -56,7 +56,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.calls"));
 			menu.addActionListener(event -> gui.showCalls(true));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showCallsMenu = menu;
@@ -64,7 +64,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.calls.specific"));
 			menu.addActionListener(event -> gui.showCalls(false));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_MASK + InputEvent.SHIFT_DOWN_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_DOWN_MASK + InputEvent.SHIFT_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showCallsSpecificMenu = menu;
@@ -72,7 +72,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.declaration"));
 			menu.addActionListener(event -> gui.getController().navigateTo(gui.cursorReference.entry));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.openEntryMenu = menu;
@@ -80,7 +80,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.back"));
 			menu.addActionListener(event -> gui.getController().openPreviousReference());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.openPreviousMenu = menu;
@@ -88,7 +88,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.forward"));
 			menu.addActionListener(event -> gui.getController().openNextReference());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.openNextMenu = menu;
@@ -96,7 +96,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.mark_deobfuscated"));
 			menu.addActionListener(event -> gui.toggleMapping());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.toggleMappingMenu = menu;
@@ -107,13 +107,13 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.zoom.in"));
 			menu.addActionListener(event -> gui.editor.offsetEditorZoom(2));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_PLUS, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_PLUS, InputEvent.CTRL_DOWN_MASK));
 			this.add(menu);
 		}
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.zoom.out"));
 			menu.addActionListener(event -> gui.editor.offsetEditorZoom(-2));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, InputEvent.CTRL_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, InputEvent.CTRL_DOWN_MASK));
 			this.add(menu);
 		}
 		{

--- a/src/main/java/cuchaz/enigma/gui/elements/PopupMenuBar.java
+++ b/src/main/java/cuchaz/enigma/gui/elements/PopupMenuBar.java
@@ -24,7 +24,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.rename"));
 			menu.addActionListener(event -> gui.startRename());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.renameMenu = menu;
@@ -32,7 +32,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.javadoc"));
 			menu.addActionListener(event -> gui.startDocChange());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.editJavadocMenu = menu;
@@ -40,7 +40,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.inheritance"));
 			menu.addActionListener(event -> gui.showInheritance());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showInheritanceMenu = menu;
@@ -48,7 +48,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.implementations"));
 			menu.addActionListener(event -> gui.showImplementations());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showImplementationsMenu = menu;
@@ -56,7 +56,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.calls"));
 			menu.addActionListener(event -> gui.showCalls(true));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showCallsMenu = menu;
@@ -64,7 +64,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.calls.specific"));
 			menu.addActionListener(event -> gui.showCalls(false));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.SHIFT_DOWN_MASK));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.CTRL_MASK + InputEvent.SHIFT_DOWN_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.showCallsSpecificMenu = menu;
@@ -72,7 +72,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.declaration"));
 			menu.addActionListener(event -> gui.getController().navigateTo(gui.cursorReference.entry));
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.openEntryMenu = menu;
@@ -80,7 +80,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.back"));
 			menu.addActionListener(event -> gui.getController().openPreviousReference());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.openPreviousMenu = menu;
@@ -88,7 +88,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.forward"));
 			menu.addActionListener(event -> gui.getController().openNextReference());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.openNextMenu = menu;
@@ -96,7 +96,7 @@ public class PopupMenuBar extends JPopupMenu {
 		{
 			JMenuItem menu = new JMenuItem(I18n.translate("popup_menu.mark_deobfuscated"));
 			menu.addActionListener(event -> gui.toggleMapping());
-			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, 0));
+			menu.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
 			menu.setEnabled(false);
 			this.add(menu);
 			this.toggleMappingMenu = menu;

--- a/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
+++ b/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
@@ -77,7 +77,11 @@ public class PanelEditor extends JEditorPane {
 							break;
 
 						case KeyEvent.VK_C:
-							gui.popupMenu.showCallsMenu.doClick();
+							if (event.isShiftDown()) {
+								gui.popupMenu.showCallsSpecificMenu.doClick();
+							} else {
+								gui.popupMenu.showCallsMenu.doClick();
+							}
 							break;
 
 						case KeyEvent.VK_O:

--- a/src/main/resources/lang/fr_fr.json
+++ b/src/main/resources/lang/fr_fr.json
@@ -3,6 +3,7 @@
 
 	"mapping_format.enigma_file": "Fichier Enigma",
 	"mapping_format.enigma_directory": "Répertoire Enigma",
+	"mapping_format.enigma_zip": "ZIP Enigma",
 	"mapping_format.tiny_v2": "Tiny v2",
 	"mapping_format.tiny_file": "Fichier Tiny",
 	"mapping_format.srg_file": "Fichier SRG",


### PR DESCRIPTION
Not as epic as Earthcomputer's PR, but enjoy this small contribution.

- Closing the Open Jar dialog without selecting anything no longer crashes Enigma
- Generate Stats dialog now appears centered instead of the top left of the screen
- Change Language dialog size is now related to the text length (the text in french is now readable)
- Popup Menu now displays the actual shortcuts (Ctrl + letter instead of just the letter)
- The shortcut to show the specific calls menu now works
- The X button now works in Crash and Javadoc dialogs (closes #186)
- ~~Obfuscated classes no longer stay in the obfuscated panel once they are renamed~~
- Removed useless imports on various classes