### PR TITLE
Fix #179

### DIFF
--- a/src/main/java/cuchaz/enigma/analysis/InterpreterPair.java
+++ b/src/main/java/cuchaz/enigma/analysis/InterpreterPair.java
@@ -97,10 +97,6 @@ public class InterpreterPair<V extends Value, W extends Value> extends Interpret
             return null;
         }
 
-        if (left != null && right != null && left.getSize() != right.getSize()) {
-            throw new IllegalStateException("sizes don't match");
-        }
-
         return new PairValue<>(left, right);
     }
 
@@ -111,10 +107,6 @@ public class InterpreterPair<V extends Value, W extends Value> extends Interpret
         public PairValue(V left, W right) {
             if (left == null && right == null) {
                 throw new IllegalArgumentException("should use null rather than pair of nulls");
-            }
-
-            if (left != null && right != null && left.getSize() != right.getSize()) {
-                throw new IllegalArgumentException("sizes don't match");
             }
 
             this.left = left;


### PR DESCRIPTION
Apparently, ASM treats all uninitialized values as having size 1, even if it came from merging two size 2 values. When merging a double and long value (both size 2),

 - `SourceInterpreter.merge` returns a source value, of size 2
 - `SimpleVerifier.merge` returns an uninitialized value, of size 1

which was causing the "sizes don't match" exception. Now, the `InterpreterPair` allows sizes to mismatch and returns the size of the first interpreter's value unless it is null (in that case, it returns the second's value's size).