### PR TITLE
Fix POM issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,13 +57,10 @@ dependencies {
     implementation 'org.ow2.asm:asm-tree:8.0'
     implementation 'org.ow2.asm:asm-util:8.0'
     implementation 'net.sf.jopt-simple:jopt-simple:6.0-alpha-3'
-    implementation 'net.fabricmc:procyon-fabric-compilertools:0.5.35.+'
+    implementation 'net.fabricmc:procyon-fabric-compilertools:0.5.35.13'
     implementation 'net.fabricmc:cfr:0.0.1'
     implementation name: "darcula", version: "1.0.0"
-    implementation 'de.sciss:syntaxpane:1.2.+'
-    implementation 'me.xdrop:fuzzywuzzy:1.2.0'
-    implementation name: "darcula", version: "1.0.0"
-    implementation 'de.sciss:syntaxpane:1.2.+'
+    implementation 'de.sciss:syntaxpane:1.2.0'
     implementation 'me.xdrop:fuzzywuzzy:1.2.0'
 
     testImplementation 'junit:junit:4.+'
@@ -162,7 +159,6 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
-            suppressPomMetadataWarningsFor "runtimeElements" // Suppress errors about versions with '+' wildcard
 
             artifact shadowJar
             artifact libJar

--- a/build.gradle
+++ b/build.gradle
@@ -158,16 +158,15 @@ task sourcesJar(type: Jar, dependsOn: generateSources) {
     from sourceSets.main.resources
 }
 
-artifacts {
-   archives shadowJar
-   archives libJar
-   archives sourcesJar
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifact jar
+            from components.java
+            suppressPomMetadataWarningsFor "runtimeElements" // Suppress errors about versions with '+' wildcard
+
+            artifact shadowJar
+            artifact libJar
+            artifact sourcesJar
         }
     }
 


### PR DESCRIPTION
Fixes #224.

- All four jars are now published again: the one with no classifier, `-all`, `-lib` and `-sources`.
- `from components.java` includes the default jar and the dependencies in the POM.