### PR TITLE
Highlight the difference between popup_menu.calls and popup_menu.calls.specific

### DIFF
--- a/src/main/resources/lang/en_us.json
+++ b/src/main/resources/lang/en_us.json
@@ -49,7 +49,7 @@
 	"popup_menu.javadoc": "Edit Javadoc",
 	"popup_menu.inheritance": "Show Inheritance",
 	"popup_menu.implementations": "Show Implementations",
-	"popup_menu.calls": "Show Calls",
+	"popup_menu.calls": "Show Calls (All Implementations)",
 	"popup_menu.calls.specific": "Show Calls (Specific)",
 	"popup_menu.declaration": "Go to Declaration",
 	"popup_menu.back": "Go back",


### PR DESCRIPTION
This changes `popup_menu.calls` to `Show Calls (All Implementations)`, to highlight the difference to `popup_menu.calls.specific` (`Show Calls (Specific)`) better.