### PR TITLE
Rewrite search dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Enigma includes the following open-source libraries:
  - [Guava](https://github.com/google/guava) (Apache-2.0)
  - [SyntaxPane](https://github.com/Sciss/SyntaxPane) (Apache-2.0)
  - [Darcula](https://github.com/bulenkov/Darcula) (Apache-2.0)
- - [fuzzywuzzy](https://github.com/xdrop/fuzzywuzzy/) (GPL-3.0)
  - [jopt-simple](https://github.com/jopt-simple/jopt-simple) (MIT)
  - [ASM](https://asm.ow2.io/) (BSD-3-Clause)
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation 'net.fabricmc:cfr:0.0.1'
     implementation 'com.bulenkov:darcula:1.0.0-bobbylight'
     implementation 'de.sciss:syntaxpane:1.2.0'
-    implementation 'me.xdrop:fuzzywuzzy:1.2.0'
     implementation 'com.github.lukeu:swing-dpi:0.6'
 
     testImplementation 'junit:junit:4.+'

--- a/src/main/java/cuchaz/enigma/gui/ClassSelector.java
+++ b/src/main/java/cuchaz/enigma/gui/ClassSelector.java
@@ -11,6 +11,17 @@
 
 package cuchaz.enigma.gui;
 
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.*;
+
+import javax.annotation.Nullable;
+import javax.swing.JOptionPane;
+import javax.swing.JTree;
+import javax.swing.event.CellEditorListener;
+import javax.swing.event.ChangeEvent;
+import javax.swing.tree.*;
+
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -20,15 +31,6 @@ import cuchaz.enigma.gui.node.ClassSelectorPackageNode;
 import cuchaz.enigma.throwables.IllegalNameException;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
-
-import javax.annotation.Nullable;
-import javax.swing.*;
-import javax.swing.event.CellEditorListener;
-import javax.swing.event.ChangeEvent;
-import javax.swing.tree.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.*;
 
 public class ClassSelector extends JTree {
 
@@ -420,7 +422,9 @@ public class ClassSelector extends JTree {
 		for (ClassSelectorPackageNode packageNode : packageNodes()) {
 			for (ClassSelectorClassNode classNode : classNodes(packageNode)) {
 				if (classNode.getClassEntry().equals(classEntry)) {
-					setSelectionPath(new TreePath(new Object[]{getModel().getRoot(), packageNode, classNode}));
+					TreePath path = new TreePath(new Object[]{getModel().getRoot(), packageNode, classNode});
+					setSelectionPath(path);
+					scrollPathToVisible(path);
 				}
 			}
 		}

--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -813,15 +813,15 @@ public class Gui {
 	public void close() {
 		if (!this.controller.isDirty()) {
 			// everything is saved, we can exit safely
-			close0();
+			exit();
 		} else {
 			// ask to save before closing
 			showDiscardDiag((response) -> {
 				if (response == JOptionPane.YES_OPTION) {
 					this.saveMapping();
-					close0();
+					exit();
 				} else if (response == JOptionPane.NO_OPTION) {
-					close0();
+					exit();
 				}
 
 				return null;
@@ -829,7 +829,7 @@ public class Gui {
 		}
 	}
 
-	private void close0() {
+	private void exit() {
 		if (searchDialog != null) {
 			searchDialog.dispose();
 		}

--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -901,6 +901,10 @@ public class Gui {
 		this.obfPanel.obfClasses.restoreExpansionState(this.obfPanel.obfClasses, stateObf);
 	}
 
+	public PanelObf getObfPanel() {
+		return obfPanel;
+	}
+
 	public PanelDeobf getDeobfPanel() {
 		return deobfPanel;
 	}

--- a/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -33,6 +33,7 @@ import cuchaz.enigma.config.Config;
 import cuchaz.enigma.config.Themes;
 import cuchaz.enigma.gui.dialog.CrashDialog;
 import cuchaz.enigma.gui.dialog.JavadocDialog;
+import cuchaz.enigma.gui.dialog.SearchDialog;
 import cuchaz.enigma.gui.elements.MenuBar;
 import cuchaz.enigma.gui.elements.PopupMenuBar;
 import cuchaz.enigma.gui.filechooser.FileChooserAny;
@@ -67,6 +68,7 @@ public class Gui {
 
 	public FileDialog jarFileChooser;
 	public FileDialog tinyMappingsFileChooser;
+	public SearchDialog searchDialog;
 	public JFileChooser enigmaMappingsFileChooser;
 	public JFileChooser exportSourceFileChooser;
 	public FileDialog exportJarFileChooser;
@@ -811,21 +813,28 @@ public class Gui {
 	public void close() {
 		if (!this.controller.isDirty()) {
 			// everything is saved, we can exit safely
-			this.frame.dispose();
-			System.exit(0);
+			close0();
 		} else {
 			// ask to save before closing
 			showDiscardDiag((response) -> {
 				if (response == JOptionPane.YES_OPTION) {
 					this.saveMapping();
-					this.frame.dispose();
+					close0();
 				} else if (response == JOptionPane.NO_OPTION) {
-					this.frame.dispose();
+					close0();
 				}
 
 				return null;
 			}, I18n.translate("prompt.close.save"), I18n.translate("prompt.close.discard"), I18n.translate("prompt.close.cancel"));
 		}
+	}
+
+	private void close0() {
+		if (searchDialog != null) {
+			searchDialog.dispose();
+		}
+		this.frame.dispose();
+		System.exit(0);
 	}
 
 	public void redraw() {
@@ -899,4 +908,12 @@ public class Gui {
 	public void setShouldNavigateOnClick(boolean shouldNavigateOnClick) {
 		this.shouldNavigateOnClick = shouldNavigateOnClick;
 	}
+
+	public SearchDialog getSearchDialog() {
+		if (searchDialog == null) {
+			searchDialog = new SearchDialog(this);
+		}
+		return searchDialog;
+	}
+
 }

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -160,7 +160,11 @@ public class SearchDialog {
 		close();
 		su.hit(e);
 		parent.getController().navigateTo(e.obf);
-		parent.getDeobfPanel().deobfClasses.setSelectionClass(e.obf);
+		if (e.deobf != null) {
+			parent.getDeobfPanel().deobfClasses.setSelectionClass(e.deobf);
+		} else {
+			parent.getObfPanel().obfClasses.setSelectionClass(e.obf);
+		}
 	}
 
 	private void close() {
@@ -211,7 +215,7 @@ public class SearchDialog {
 
 		public static SearchEntryImpl from(ClassEntry e, GuiController controller) {
 			ClassEntry deobf = controller.project.getMapper().deobfuscate(e);
-			if (deobf == e) deobf = null;
+			if (deobf.equals(e)) deobf = null;
 			return new SearchEntryImpl(e, deobf);
 		}
 

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -48,9 +48,9 @@ public class SearchDialog {
 		this.parent = parent;
 
 		this.classes = parent.getController().project.getJarIndex().getEntryIndex().getClasses().parallelStream()
+				.filter(e -> !e.isInnerClass())
 				.map(e -> SearchEntryImpl.from(e, parent.getController()))
 				.collect(Collectors.toList());
-		this.classes.removeIf(e -> e.obf.isInnerClass());
 
 		su = new SearchUtil<>();
 		su.addAll(classes);
@@ -115,10 +115,10 @@ public class SearchDialog {
 
 		JPanel buttonBar = new JPanel();
 		buttonBar.setLayout(new FlowLayout(FlowLayout.RIGHT));
-		JButton open = new JButton("Open");
+		JButton open = new JButton(I18n.translate("prompt.open"));
 		open.addActionListener(event -> openSelected());
 		buttonBar.add(open);
-		JButton cancel = new JButton("Cancel");
+		JButton cancel = new JButton(I18n.translate("prompt.cancel"));
 		cancel.addActionListener(event -> close());
 		buttonBar.add(cancel);
 		contentPane.add(buttonBar, BorderLayout.SOUTH);

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -11,150 +11,220 @@
 
 package cuchaz.enigma.gui.dialog;
 
-import com.google.common.collect.Lists;
-import cuchaz.enigma.gui.Gui;
-import cuchaz.enigma.translation.representation.entry.ClassEntry;
-import cuchaz.enigma.utils.I18n;
-import cuchaz.enigma.gui.util.ScaleUtil;
-import me.xdrop.fuzzywuzzy.FuzzySearch;
-import me.xdrop.fuzzywuzzy.model.ExtractedResult;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.event.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import java.awt.*;
-import java.awt.event.*;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import cuchaz.enigma.gui.Gui;
+import cuchaz.enigma.gui.GuiController;
+import cuchaz.enigma.gui.util.AbstractListCellRenderer;
+import cuchaz.enigma.gui.util.ScaleUtil;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.utils.I18n;
+import cuchaz.enigma.utils.search.SearchEntry;
+import cuchaz.enigma.utils.search.SearchUtil;
 
 public class SearchDialog {
 
 	private JTextField searchField;
-	private JList<String> classList;
-	private JFrame frame;
+	private JList<SearchEntryImpl> classList;
+	private JDialog dialog;
 
-	private Gui parent;
-	private List<ClassEntry> deobfClasses;
-
-	private KeyEventDispatcher keyEventDispatcher;
+	private final Gui parent;
+	private final List<SearchEntryImpl> classes;
+	private final SearchUtil<SearchEntryImpl> su;
 
 	public SearchDialog(Gui parent) {
 		this.parent = parent;
 
-		deobfClasses = Lists.newArrayList();
-		this.parent.getController().addSeparatedClasses(Lists.newArrayList(), deobfClasses);
-		deobfClasses.removeIf(ClassEntry::isInnerClass);
+		this.classes = parent.getController().project.getJarIndex().getEntryIndex().getClasses().parallelStream()
+				.map(e -> SearchEntryImpl.from(e, parent.getController()))
+				.collect(Collectors.toList());
+		this.classes.removeIf(e -> e.obf.isInnerClass());
+
+		su = new SearchUtil<>();
+		su.addAll(classes);
 	}
 
 	public void show() {
-		frame = new JFrame(I18n.translate("menu.view.search"));
-		frame.setVisible(false);
-		JPanel pane = new JPanel();
-		pane.setBorder(new EmptyBorder(5, 10, 5, 10));
+		dialog = new JDialog(parent.getFrame(), I18n.translate("menu.view.search"), true);
+		JPanel contentPane = new JPanel();
+		contentPane.setBorder(ScaleUtil.createEmptyBorder(4, 4, 4, 4));
+		contentPane.setLayout(new BorderLayout(ScaleUtil.scale(4), ScaleUtil.scale(4)));
 
-		addRow(pane, jPanel -> {
-			searchField = new JTextField("", 20);
+		searchField = new JTextField();
+		searchField.getDocument().addDocumentListener(new DocumentListener() {
 
-			searchField.addKeyListener(new KeyAdapter() {
-				@Override
-				public void keyTyped(KeyEvent keyEvent) {
-					updateList();
-				}
-			});
+			@Override
+			public void insertUpdate(DocumentEvent e) {
+				updateList();
+			}
 
-			jPanel.add(searchField);
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				updateList();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				updateList();
+			}
+
 		});
-
-		addRow(pane, jPanel -> {
-			classList = new JList<>();
-			classList.setLayoutOrientation(JList.VERTICAL);
-			classList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-
-			classList.addMouseListener(new MouseAdapter() {
-				@Override
-				public void mouseClicked(MouseEvent mouseEvent) {
-					if(mouseEvent.getClickCount() >= 2){
-						openSelected();
-					}
+		searchField.addKeyListener(new KeyAdapter() {
+			@Override
+			public void keyPressed(KeyEvent e) {
+				if (e.getKeyCode() == KeyEvent.VK_DOWN) {
+					int next = classList.isSelectionEmpty() ? 0 : classList.getSelectedIndex() + 1;
+					classList.setSelectedIndex(next);
+				} else if (e.getKeyCode() == KeyEvent.VK_UP) {
+					int prev = classList.isSelectionEmpty() ? classList.getModel().getSize() : classList.getSelectedIndex() - 1;
+					classList.setSelectedIndex(prev);
+				} else if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+					close();
 				}
-			});
-			jPanel.add(classList);
+			}
 		});
+		searchField.addActionListener(e -> openSelected());
+		contentPane.add(searchField, BorderLayout.NORTH);
 
-
-		keyEventDispatcher = keyEvent -> {
-			if(!frame.isVisible()){
-				return false;
+		classList = new JList<>();
+		classList.setCellRenderer(new ListCellRendererImpl());
+		classList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		classList.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent mouseEvent) {
+				if (mouseEvent.getClickCount() >= 2) {
+					int idx = classList.locationToIndex(mouseEvent.getPoint());
+					SearchEntryImpl entry = classList.getModel().getElementAt(idx);
+					openEntry(entry.obf);
+				}
 			}
-			if(keyEvent.getKeyCode() == KeyEvent.VK_DOWN){
-				int next = classList.isSelectionEmpty() ? 0 : classList.getSelectedIndex() + 1;
-				classList.setSelectedIndex(next);
-			}
-			if(keyEvent.getKeyCode() == KeyEvent.VK_UP){
-				int next = classList.isSelectionEmpty() ? classList.getModel().getSize() : classList.getSelectedIndex() - 1;
-				classList.setSelectedIndex(next);
-			}
-			if(keyEvent.getKeyCode() == KeyEvent.VK_ENTER){
-				openSelected();
-			}
-			if(keyEvent.getKeyCode() == KeyEvent.VK_ESCAPE){
-				close();
-			}
-			return false;
-		};
+		});
+		contentPane.add(new JScrollPane(classList, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_NEVER), BorderLayout.CENTER);
 
-		KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(keyEventDispatcher);
+		JPanel buttonBar = new JPanel();
+		buttonBar.setLayout(new FlowLayout(FlowLayout.RIGHT));
+		JButton open = new JButton("Open");
+		open.addActionListener(event -> openSelected());
+		buttonBar.add(open);
+		JButton cancel = new JButton("Cancel");
+		cancel.addActionListener(event -> close());
+		buttonBar.add(cancel);
+		contentPane.add(buttonBar, BorderLayout.SOUTH);
 
-		frame.setContentPane(pane);
-		frame.setLayout(new BoxLayout(pane, BoxLayout.Y_AXIS));
+		dialog.setContentPane(contentPane);
 
-		frame.setSize(ScaleUtil.getDimension(360, 500));
-		frame.setAlwaysOnTop(true);
-		frame.setResizable(false);
-		frame.setLocationRelativeTo(parent.getFrame());
-		frame.setVisible(true);
-		frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+		dialog.setSize(ScaleUtil.getDimension(400, 500));
+		dialog.setLocationRelativeTo(parent.getFrame());
+		dialog.setVisible(true);
+		dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 
-		searchField.requestFocusInWindow();
+		dialog.requestFocus();
+		searchField.requestFocus();
 	}
 
-	private void openSelected(){
-		close();
-		if(classList.isSelectionEmpty()){
-			return;
+	private void openSelected() {
+		SearchEntryImpl selectedValue = classList.getSelectedValue();
+		if (selectedValue != null) {
+			openEntry(selectedValue.obf);
 		}
-		deobfClasses.stream()
-			.filter(classEntry -> classEntry.getSimpleName().equals(classList.getSelectedValue())).
-			findFirst()
-			.ifPresent(classEntry -> {
-				parent.getController().navigateTo(classEntry);
-				parent.getDeobfPanel().deobfClasses.setSelectionClass(classEntry);
-			});
 	}
 
-	private void close(){
-		frame.dispatchEvent(new WindowEvent(frame, WindowEvent.WINDOW_CLOSING));
-		KeyboardFocusManager.getCurrentKeyboardFocusManager().removeKeyEventDispatcher(keyEventDispatcher);
+	private void openEntry(ClassEntry e) {
+		close();
+		parent.getController().navigateTo(e);
+		parent.getDeobfPanel().deobfClasses.setSelectionClass(e);
 	}
 
-	private void addRow(JPanel pane, Consumer<JPanel> consumer) {
-		JPanel panel = new JPanel(new FlowLayout());
-		consumer.accept(panel);
-		pane.add(panel, BorderLayout.CENTER);
+	private void close() {
+		dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
 	}
 
-	//Updates the list of class names
+	// Updates the list of class names
 	private void updateList() {
-		DefaultListModel<String> listModel = new DefaultListModel<>();
+		DefaultListModel<SearchEntryImpl> listModel = new DefaultListModel<>();
 
-		//Basic search using the Fuzzy libary
-		//TODO improve on this, to not just work from string and to keep the ClassEntry
-		List<ExtractedResult> results = FuzzySearch.extractTop(searchField.getText(), deobfClasses.stream().map(ClassEntry::getSimpleName).collect(Collectors.toList()), 25);
-		results.forEach(extractedResult -> listModel.addElement(extractedResult.getString()));
+		List<SearchEntryImpl> results = su.search(searchField.getText(), 25);
+		results.forEach(listModel::addElement);
 
 		classList.setModel(listModel);
 	}
 
+	private static final class SearchEntryImpl implements SearchEntry {
 
+		public final ClassEntry obf;
+		public final ClassEntry deobf;
+
+		private SearchEntryImpl(ClassEntry obf, ClassEntry deobf) {
+			this.obf = obf;
+			this.deobf = deobf;
+		}
+
+		@Override
+		public List<String> getSearchableNames() {
+			if (deobf != null) {
+				return Arrays.asList(obf.getSimpleName(), deobf.getSimpleName());
+			} else {
+				return Collections.singletonList(obf.getSimpleName());
+			}
+		}
+
+		@Override
+		public String toString() {
+			return String.format("SearchEntryImpl { obf: %s, deobf: %s }", obf, deobf);
+		}
+
+		public static SearchEntryImpl from(ClassEntry e, GuiController controller) {
+			ClassEntry deobf = controller.project.getMapper().deobfuscate(e);
+			if (deobf == e) deobf = null;
+			return new SearchEntryImpl(e, deobf);
+		}
+
+	}
+
+	private static final class ListCellRendererImpl extends AbstractListCellRenderer<SearchEntryImpl> {
+
+		private JLabel mainName;
+		private JLabel secondaryName;
+
+		public ListCellRendererImpl() {
+			this.setLayout(new BorderLayout());
+
+			mainName = new JLabel();
+			this.add(mainName, BorderLayout.WEST);
+
+			secondaryName = new JLabel();
+			secondaryName.setFont(secondaryName.getFont().deriveFont(Font.ITALIC, 12));
+			secondaryName.setForeground(Color.GRAY);
+			this.add(secondaryName, BorderLayout.EAST);
+		}
+
+		@Override
+		public void updateUiForEntry(JList<? extends SearchEntryImpl> list, SearchEntryImpl value, int index, boolean isSelected, boolean cellHasFocus) {
+			if (value.deobf == null) {
+				mainName.setText(value.obf.getSimpleName());
+				mainName.setToolTipText(value.obf.getFullName());
+				secondaryName.setText("");
+				secondaryName.setToolTipText("");
+			} else {
+				mainName.setText(value.deobf.getSimpleName());
+				mainName.setToolTipText(value.deobf.getFullName());
+				secondaryName.setText(value.obf.getSimpleName());
+				secondaryName.setToolTipText(value.obf.getFullName());
+			}
+		}
+
+	}
 
 }

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -155,7 +155,7 @@ public class SearchDialog {
 	private void updateList() {
 		DefaultListModel<SearchEntryImpl> listModel = new DefaultListModel<>();
 
-		List<SearchEntryImpl> results = su.search(searchField.getText(), 25);
+		List<SearchEntryImpl> results = su.search(searchField.getText(), 100);
 		results.forEach(listModel::addElement);
 
 		classList.setModel(listModel);

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -46,7 +46,6 @@ public class SearchDialog {
 	public SearchDialog(Gui parent) {
 		this.parent = parent;
 
-
 		su = new SearchUtil<>();
 
 		dialog = new JDialog(parent.getFrame(), I18n.translate("menu.view.search"), true);
@@ -79,9 +78,11 @@ public class SearchDialog {
 				if (e.getKeyCode() == KeyEvent.VK_DOWN) {
 					int next = classList.isSelectionEmpty() ? 0 : classList.getSelectedIndex() + 1;
 					classList.setSelectedIndex(next);
+					classList.ensureIndexIsVisible(next);
 				} else if (e.getKeyCode() == KeyEvent.VK_UP) {
 					int prev = classList.isSelectionEmpty() ? classList.getModel().getSize() : classList.getSelectedIndex() - 1;
 					classList.setSelectedIndex(prev);
+					classList.ensureIndexIsVisible(prev);
 				} else if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
 					close();
 				}
@@ -146,10 +147,6 @@ public class SearchDialog {
 		searchField.selectAll();
 
 		dialog.setVisible(true);
-	}
-
-	public SearchUtil<SearchEntryImpl> getSearchUtil() {
-		return su;
 	}
 
 	private void openSelected() {
@@ -222,8 +219,8 @@ public class SearchDialog {
 
 	private static final class ListCellRendererImpl extends AbstractListCellRenderer<SearchEntryImpl> {
 
-		private JLabel mainName;
-		private JLabel secondaryName;
+		private final JLabel mainName;
+		private final JLabel secondaryName;
 
 		public ListCellRendererImpl() {
 			this.setLayout(new BorderLayout());

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -155,8 +155,9 @@ public class SearchDialog {
 	private void updateList() {
 		DefaultListModel<SearchEntryImpl> listModel = new DefaultListModel<>();
 
-		List<SearchEntryImpl> results = su.search(searchField.getText(), 100);
-		results.forEach(listModel::addElement);
+		su.search(searchField.getText())
+				.limit(100)
+				.forEach(listModel::addElement);
 
 		classList.setModel(listModel);
 	}

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -19,7 +19,6 @@ import java.awt.event.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;

--- a/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -229,7 +229,7 @@ public class SearchDialog {
 			this.add(mainName, BorderLayout.WEST);
 
 			secondaryName = new JLabel();
-			secondaryName.setFont(secondaryName.getFont().deriveFont(Font.ITALIC, 12));
+			secondaryName.setFont(secondaryName.getFont().deriveFont(Font.ITALIC));
 			secondaryName.setForeground(Color.GRAY);
 			this.add(secondaryName, BorderLayout.EAST);
 		}

--- a/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
+++ b/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
@@ -325,7 +325,7 @@ public class MenuBar extends JMenuBar {
 				menu.add(search);
 				search.addActionListener(event -> {
 					if (this.gui.getController().project != null) {
-						new SearchDialog(this.gui).show();
+						this.gui.getSearchDialog().show();
 					}
 				});
 

--- a/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
+++ b/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
@@ -29,6 +29,16 @@ import cuchaz.enigma.translation.mapping.serde.MappingFormat;
 import cuchaz.enigma.utils.I18n;
 import cuchaz.enigma.utils.Pair;
 
+import javax.swing.*;
+
+import cuchaz.enigma.config.Config;
+import cuchaz.enigma.config.Themes;
+import cuchaz.enigma.gui.Gui;
+import cuchaz.enigma.gui.dialog.AboutDialog;
+import cuchaz.enigma.gui.stats.StatsMember;
+import cuchaz.enigma.translation.mapping.serde.MappingFormat;
+import cuchaz.enigma.utils.I18n;
+
 public class MenuBar extends JMenuBar {
 
 	public final JMenuItem closeJarMenu;

--- a/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
+++ b/src/main/java/cuchaz/enigma/gui/panels/PanelEditor.java
@@ -126,7 +126,7 @@ public class PanelEditor extends JEditorPane {
 			public void keyTyped(KeyEvent event) {
 				if (!gui.popupMenu.renameMenu.isEnabled()) return;
 
-				if (!event.isControlDown() && !event.isAltDown()) {
+				if (!event.isControlDown() && !event.isAltDown() && Character.isJavaIdentifierPart(event.getKeyChar())) {
 					EnigmaProject project = gui.getController().project;
 					EntryReference<Entry<?>, Entry<?>> reference = project.getMapper().deobfuscate(gui.cursorReference);
 					Entry<?> entry = reference.getNameableEntry();

--- a/src/main/java/cuchaz/enigma/gui/util/AbstractListCellRenderer.java
+++ b/src/main/java/cuchaz/enigma/gui/util/AbstractListCellRenderer.java
@@ -42,7 +42,7 @@ public abstract class AbstractListCellRenderer<E> extends JPanel implements List
 
 	@Override
 	public Component getListCellRendererComponent(JList<? extends E> list, E value, int index, boolean isSelected, boolean cellHasFocus) {
-		updateUiForEntry(list,value,index,isSelected,cellHasFocus);
+		updateUiForEntry(list, value, index, isSelected, cellHasFocus);
 
 		if (isSelected) {
 			setBackground(list.getSelectionBackground());

--- a/src/main/java/cuchaz/enigma/gui/util/AbstractListCellRenderer.java
+++ b/src/main/java/cuchaz/enigma/gui/util/AbstractListCellRenderer.java
@@ -1,0 +1,75 @@
+package cuchaz.enigma.gui.util;
+
+import java.awt.Component;
+import java.awt.event.MouseEvent;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+
+public abstract class AbstractListCellRenderer<E> extends JPanel implements ListCellRenderer<E> {
+
+	private static final Border NO_FOCUS_BORDER = BorderFactory.createEmptyBorder(1, 1, 1, 1);
+
+	public AbstractListCellRenderer() {
+		setBorder(getNoFocusBorder());
+	}
+
+	protected Border getNoFocusBorder() {
+		Border border = UIManager.getLookAndFeel().getDefaults().getBorder("List.List.cellNoFocusBorder");
+		if (border == null) {
+			return NO_FOCUS_BORDER;
+		}
+		return border;
+	}
+
+	protected Border getBorder(boolean isSelected, boolean cellHasFocus) {
+		Border b = null;
+		if (cellHasFocus) {
+			UIDefaults defaults = UIManager.getLookAndFeel().getDefaults();
+			if (isSelected) {
+				b = defaults.getBorder("List.focusSelectedCellHighlightBorder");
+			}
+			if (b == null) {
+				b = defaults.getBorder("List.focusCellHighlightBorder");
+			}
+		} else {
+			b = getNoFocusBorder();
+		}
+		return b;
+	}
+
+	public abstract void updateUiForEntry(JList<? extends E> list, E value, int index, boolean isSelected, boolean cellHasFocus);
+
+	@Override
+	public Component getListCellRendererComponent(JList<? extends E> list, E value, int index, boolean isSelected, boolean cellHasFocus) {
+		updateUiForEntry(list,value,index,isSelected,cellHasFocus);
+
+		if (isSelected) {
+			setBackground(list.getSelectionBackground());
+			setForeground(list.getSelectionForeground());
+		} else {
+			setBackground(list.getBackground());
+			setForeground(list.getForeground());
+		}
+
+		setEnabled(list.isEnabled());
+		setFont(list.getFont());
+
+		setBorder(getBorder(isSelected, cellHasFocus));
+
+		// This isn't the width of the cell, but it's close enough for where it's needed (getComponentAt in getToolTipText)
+		setSize(list.getWidth(), getPreferredSize().height);
+
+		return this;
+	}
+
+	@Override
+	public String getToolTipText(MouseEvent event) {
+		Component c = getComponentAt(event.getPoint());
+		if (c instanceof JComponent) {
+			return ((JComponent) c).getToolTipText();
+		}
+		return getToolTipText();
+	}
+
+}

--- a/src/main/java/cuchaz/enigma/gui/util/ScaleUtil.java
+++ b/src/main/java/cuchaz/enigma/gui/util/ScaleUtil.java
@@ -7,7 +7,9 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.BorderFactory;
 import javax.swing.UIManager;
+import javax.swing.border.Border;
 
 import com.github.swingdpi.UiDefaultsScaler;
 import com.github.swingdpi.plaf.BasicTweaker;
@@ -67,6 +69,10 @@ public class ScaleUtil {
 
 	public static int scale(int i) {
 		return (int) (i * getScaleFactor());
+	}
+
+	public static Border createEmptyBorder(int top, int left, int bottom, int right) {
+		return BorderFactory.createEmptyBorder(scale(top), scale(left), scale(bottom), scale(right));
 	}
 
 	public static int invert(int i) {

--- a/src/main/java/cuchaz/enigma/utils/search/SearchEntry.java
+++ b/src/main/java/cuchaz/enigma/utils/search/SearchEntry.java
@@ -1,0 +1,9 @@
+package cuchaz.enigma.utils.search;
+
+import java.util.List;
+
+public interface SearchEntry {
+
+	List<String> getSearchableNames();
+
+}

--- a/src/main/java/cuchaz/enigma/utils/search/SearchEntry.java
+++ b/src/main/java/cuchaz/enigma/utils/search/SearchEntry.java
@@ -6,4 +6,12 @@ public interface SearchEntry {
 
 	List<String> getSearchableNames();
 
+	/**
+	 * Returns a type that uniquely identifies this search entry across possible changes.
+	 * This is used for tracking the amount of times this entry has been selected.
+	 *
+	 * @return a unique identifier for this search entry
+	 */
+	String getIdentifier();
+
 }

--- a/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
+++ b/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
@@ -1,0 +1,142 @@
+package cuchaz.enigma.utils.search;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import cuchaz.enigma.utils.Pair;
+
+public class SearchUtil<T extends SearchEntry> {
+
+	private final Map<T, Entry<T>> entries = new HashMap<>();
+
+	public void add(T entry) {
+		Entry<T> e = Entry.from(entry);
+		entries.put(entry, e);
+	}
+
+	public void addAll(Collection<T> entries) {
+		this.entries.putAll(entries.parallelStream().collect(Collectors.toMap(e -> e, Entry::from)));
+	}
+
+	public void remove(T entry) {
+		entries.remove(entry);
+	}
+
+	public void clear() {
+		entries.clear();
+	}
+
+	public List<T> search(String term, int limit) {
+		return entries.values().parallelStream()
+				.map(e -> new Pair<>(e, e.getScore(term)))
+				.filter(e -> e.b > 0)
+				.sorted(Comparator.comparingDouble(o -> -o.b))
+				.map(e -> e.a.searchEntry)
+				.limit(limit)
+				.collect(Collectors.toList());
+	}
+
+	public void hit(T entry) {
+		Entry<T> e = entries.get(entry);
+		if (e != null) e.hit();
+	}
+
+	private static final class Entry<T extends SearchEntry> {
+
+		public final T searchEntry;
+		public final String[][] components;
+		private int hits = 0;
+
+		private Entry(T searchEntry, String[][] components) {
+			this.searchEntry = searchEntry;
+			this.components = components;
+		}
+
+		public void hit() {
+			hits += 1;
+		}
+
+		public float getScore(String term) {
+			term = term.toUpperCase(Locale.ROOT);
+			float maxScore = 0;
+			for (String[] name : components) {
+				float baseScore = 0;
+				float scorePerChar = 1f / Arrays.stream(name).mapToInt(String::length).sum();
+				String remaining = term;
+				for (String component : name) {
+					component = component.toUpperCase(Locale.ROOT);
+					int l = compareEqualLength(remaining, component);
+					remaining = remaining.substring(l);
+					baseScore += scorePerChar * l;
+				}
+				if (!remaining.isEmpty()) {
+					baseScore = 0;
+				}
+				maxScore = Math.max(maxScore, baseScore);
+			}
+			return maxScore * (hits + 1);
+		}
+
+		public static <T extends SearchEntry> Entry<T> from(T e) {
+			List<String> searchableNames = e.getSearchableNames();
+			String[][] components = new String[searchableNames.size()][];
+			for (int i = 0; i < searchableNames.size(); i++) {
+				String name = searchableNames.get(i);
+				components[i] = wordwiseSplit(name).toArray(new String[0]);
+			}
+			return new Entry<>(e, components);
+		}
+
+	}
+
+	private static int compareEqualLength(String s1, String s2) {
+		int len = 0;
+		while (len < s1.length() && len < s2.length() && s1.charAt(len) == s2.charAt(len)) {
+			len += 1;
+		}
+		return len;
+	}
+
+	private static List<String> wordwiseSplit(String name) {
+		List<String> list = new ArrayList<>();
+		while (!name.isEmpty()) {
+			int take;
+			if (Character.isLetter(name.charAt(0))) {
+				if (name.length() == 1) {
+					take = 1;
+				} else {
+					boolean nextSegmentIsUppercase = Character.isUpperCase(name.charAt(0)) && Character.isUpperCase(name.charAt(1));
+					if (nextSegmentIsUppercase) {
+						int nextLowercase = 1;
+						while (Character.isUpperCase(name.charAt(nextLowercase))) {
+							nextLowercase += 1;
+							if (nextLowercase == name.length()) {
+								nextLowercase += 1;
+								break;
+							}
+						}
+						take = nextLowercase - 1;
+					} else {
+						int nextUppercase = 1;
+						while (nextUppercase < name.length() && Character.isLowerCase(name.charAt(nextUppercase))) {
+							nextUppercase += 1;
+						}
+						take = nextUppercase;
+					}
+				}
+			} else if (Character.isDigit(name.charAt(0))) {
+				int nextNonNum = 1;
+				while (nextNonNum < name.length() && Character.isLetter(name.charAt(nextNonNum)) && !Character.isLowerCase(name.charAt(nextNonNum))) {
+					nextNonNum += 1;
+				}
+				take = nextNonNum;
+			} else {
+				take = 1;
+			}
+			list.add(name.substring(0, take));
+			name = name.substring(take);
+		}
+		return list;
+	}
+
+}

--- a/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
+++ b/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
@@ -1,7 +1,9 @@
 package cuchaz.enigma.utils.search;
 
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import cuchaz.enigma.utils.Pair;
 
@@ -26,14 +28,13 @@ public class SearchUtil<T extends SearchEntry> {
 		entries.clear();
 	}
 
-	public List<T> search(String term, int limit) {
+	public Stream<T> search(String term) {
 		return entries.values().parallelStream()
 				.map(e -> new Pair<>(e, e.getScore(term)))
 				.filter(e -> e.b > 0)
 				.sorted(Comparator.comparingDouble(o -> -o.b))
 				.map(e -> e.a.searchEntry)
-				.limit(limit)
-				.collect(Collectors.toList());
+				.sequential();
 	}
 
 	public void hit(T entry) {
@@ -57,41 +58,66 @@ public class SearchUtil<T extends SearchEntry> {
 		}
 
 		public float getScore(String term) {
-			term = term.toUpperCase(Locale.ROOT);
-			float maxScore = 0;
-			for (String[] name : components) {
-				float scorePerChar = 1f / Arrays.stream(name).mapToInt(String::length).sum();
-				Map<String, Float> snapshots = new HashMap<>();
-				snapshots.put(term, 0f);
-				for (int componentIndex = 0; componentIndex < name.length; componentIndex++) {
-					String component = name[componentIndex];
-					float posMultiplier = (name.length - componentIndex) * 0.3f;
-					Map<String, Float> newSnapshots = new HashMap<>();
-					for (Map.Entry<String, Float> snapshot : snapshots.entrySet()) {
-						String remaining = snapshot.getKey();
-						float score = snapshot.getValue();
-						component = component.toUpperCase(Locale.ROOT);
-						int l = compareEqualLength(remaining, component);
-						for (int i = 1; i <= l; i++) {
-							float baseScore = scorePerChar * i;
-							float chainBonus = (i - 1) * 0.5f;
-							newSnapshots.put(remaining.substring(i), score + baseScore * posMultiplier + chainBonus);
-						}
-					}
-					newSnapshots.forEach((k, v) -> snapshots.compute(k, (_k, v1) -> v1 == null ? v : Math.max(v, v1)));
-				}
-				maxScore = Math.max(maxScore, snapshots.getOrDefault("", 0f));
-			}
+			String ucTerm = term.toUpperCase(Locale.ROOT);
+			float maxScore = (float) Arrays.stream(components)
+					.mapToDouble(name -> getScoreFor(ucTerm, name))
+					.max().orElse(0.0);
 			return maxScore * (hits + 1);
 		}
 
-		public static <T extends SearchEntry> Entry<T> from(T e) {
-			List<String> searchableNames = e.getSearchableNames();
-			String[][] components = new String[searchableNames.size()][];
-			for (int i = 0; i < searchableNames.size(); i++) {
-				String name = searchableNames.get(i);
-				components[i] = wordwiseSplit(name).toArray(new String[0]);
+		/**
+		 * Computes the score for the given <code>name</code> against the given search term.
+		 *
+		 * @param term the search term (expected to be upper-case)
+		 * @param name the entry name, split at word boundaries (see {@link SearchUtil#wordwiseSplit(String)})
+		 * @return the computed score for the entry
+		 */
+		private static float getScoreFor(String term, String[] name) {
+			int totalLength = Arrays.stream(name).mapToInt(String::length).sum();
+			float scorePerChar = 1f / totalLength;
+
+			// This map contains a snapshot of all the states the search has
+			// been in. The keys are the remaining characters of the search
+			// term, the values are the maximum scores for that remaining
+			// search term part.
+			Map<String, Float> snapshots = new HashMap<>();
+			snapshots.put(term, 0f);
+
+			// For each component, start at each existing snapshot, searching
+			// for the next longest match, and calculate the new score for each
+			// match length until the maximum. Then the new scores are put back
+			// into the snapshot map.
+			for (int componentIndex = 0; componentIndex < name.length; componentIndex++) {
+				String component = name[componentIndex];
+				float posMultiplier = (name.length - componentIndex) * 0.3f;
+				Map<String, Float> newSnapshots = new HashMap<>();
+				for (Map.Entry<String, Float> snapshot : snapshots.entrySet()) {
+					String remaining = snapshot.getKey();
+					float score = snapshot.getValue();
+					component = component.toUpperCase(Locale.ROOT);
+					int l = compareEqualLength(remaining, component);
+					for (int i = 1; i <= l; i++) {
+						float baseScore = scorePerChar * i;
+						float chainBonus = (i - 1) * 0.5f;
+						newSnapshots.put(remaining.substring(i), score + baseScore * posMultiplier + chainBonus);
+					}
+				}
+				merge(snapshots, newSnapshots, Math::max);
 			}
+
+			// Only return the score for when the search term was completely
+			// consumed.
+			return snapshots.getOrDefault("", 0f);
+		}
+
+		private static <K, V> void merge(Map<K, V> self, Map<K, V> source, BiFunction<V, V, V> combiner) {
+			source.forEach((k, v) -> self.compute(k, (_k, v1) -> v1 == null ? v : v == null ? v1 : combiner.apply(v, v1)));
+		}
+
+		public static <T extends SearchEntry> Entry<T> from(T e) {
+			String[][] components = e.getSearchableNames().parallelStream()
+					.map(SearchUtil::wordwiseSplit)
+					.toArray(String[][]::new);
 			return new Entry<>(e, components);
 		}
 
@@ -105,20 +131,35 @@ public class SearchUtil<T extends SearchEntry> {
 		return len;
 	}
 
-	private static List<String> wordwiseSplit(String name) {
+	/**
+	 * Splits the given input into components, trying to detect word parts.
+	 * <p>
+	 * Example of how words get split (using <code>|</code> as seperator):
+	 * <p><code>MinecraftClientGame -> Minecraft|Client|Game</code></p>
+	 * <p><code>MinecraftClientGame -> Minecraft|Client|Game</code></p>
+	 * <p><code>HTTPInputStream -> HTTP|Input|Stream</code></p>
+	 * <p><code>class_932 -> class|_|932</code></p>
+	 * <p><code>X11FontManager -> X|11|Font|Manager</code></p>
+	 * <p><code>openHTTPConnection -> open|HTTP|Connection</code></p>
+	 * <p><code>open_http_connection -> open|_|http|_|connection</code></p>
+	 *
+	 * @param input the input to split
+	 * @return the resulting components
+	 */
+	private static String[] wordwiseSplit(String input) {
 		List<String> list = new ArrayList<>();
-		while (!name.isEmpty()) {
+		while (!input.isEmpty()) {
 			int take;
-			if (Character.isLetter(name.charAt(0))) {
-				if (name.length() == 1) {
+			if (Character.isLetter(input.charAt(0))) {
+				if (input.length() == 1) {
 					take = 1;
 				} else {
-					boolean nextSegmentIsUppercase = Character.isUpperCase(name.charAt(0)) && Character.isUpperCase(name.charAt(1));
+					boolean nextSegmentIsUppercase = Character.isUpperCase(input.charAt(0)) && Character.isUpperCase(input.charAt(1));
 					if (nextSegmentIsUppercase) {
 						int nextLowercase = 1;
-						while (Character.isUpperCase(name.charAt(nextLowercase))) {
+						while (Character.isUpperCase(input.charAt(nextLowercase))) {
 							nextLowercase += 1;
-							if (nextLowercase == name.length()) {
+							if (nextLowercase == input.length()) {
 								nextLowercase += 1;
 								break;
 							}
@@ -126,25 +167,25 @@ public class SearchUtil<T extends SearchEntry> {
 						take = nextLowercase - 1;
 					} else {
 						int nextUppercase = 1;
-						while (nextUppercase < name.length() && Character.isLowerCase(name.charAt(nextUppercase))) {
+						while (nextUppercase < input.length() && Character.isLowerCase(input.charAt(nextUppercase))) {
 							nextUppercase += 1;
 						}
 						take = nextUppercase;
 					}
 				}
-			} else if (Character.isDigit(name.charAt(0))) {
+			} else if (Character.isDigit(input.charAt(0))) {
 				int nextNonNum = 1;
-				while (nextNonNum < name.length() && Character.isLetter(name.charAt(nextNonNum)) && !Character.isLowerCase(name.charAt(nextNonNum))) {
+				while (nextNonNum < input.length() && Character.isLetter(input.charAt(nextNonNum)) && !Character.isLowerCase(input.charAt(nextNonNum))) {
 					nextNonNum += 1;
 				}
 				take = nextNonNum;
 			} else {
 				take = 1;
 			}
-			list.add(name.substring(0, take));
-			name = name.substring(take);
+			list.add(input.substring(0, take));
+			input = input.substring(take);
 		}
-		return list;
+		return list.toArray(new String[0]);
 	}
 
 }

--- a/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
+++ b/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
@@ -10,10 +10,15 @@ import cuchaz.enigma.utils.Pair;
 public class SearchUtil<T extends SearchEntry> {
 
 	private final Map<T, Entry<T>> entries = new HashMap<>();
+	private final Map<String, Integer> hitCount = new HashMap<>();
 
 	public void add(T entry) {
 		Entry<T> e = Entry.from(entry);
 		entries.put(entry, e);
+	}
+
+	public void add(Entry<T> entry) {
+		entries.put(entry.searchEntry, entry);
 	}
 
 	public void addAll(Collection<T> entries) {
@@ -28,9 +33,13 @@ public class SearchUtil<T extends SearchEntry> {
 		entries.clear();
 	}
 
+	public void clearHits() {
+		hitCount.clear();
+	}
+
 	public Stream<T> search(String term) {
 		return entries.values().parallelStream()
-				.map(e -> new Pair<>(e, e.getScore(term)))
+				.map(e -> new Pair<>(e, e.getScore(term, hitCount.getOrDefault(e.searchEntry.getIdentifier(), 0))))
 				.filter(e -> e.b > 0)
 				.sorted(Comparator.comparingDouble(o -> -o.b))
 				.map(e -> e.a.searchEntry)
@@ -38,26 +47,22 @@ public class SearchUtil<T extends SearchEntry> {
 	}
 
 	public void hit(T entry) {
-		Entry<T> e = entries.get(entry);
-		if (e != null) e.hit();
+		if (entries.containsKey(entry)) {
+			hitCount.compute(entry.getIdentifier(), (_id, i) -> i == null ? 1 : i + 1);
+		}
 	}
 
-	private static final class Entry<T extends SearchEntry> {
+	public static final class Entry<T extends SearchEntry> {
 
 		public final T searchEntry;
-		public final String[][] components;
-		private int hits = 0;
+		private final String[][] components;
 
 		private Entry(T searchEntry, String[][] components) {
 			this.searchEntry = searchEntry;
 			this.components = components;
 		}
 
-		public void hit() {
-			hits += 1;
-		}
-
-		public float getScore(String term) {
+		public float getScore(String term, int hits) {
 			String ucTerm = term.toUpperCase(Locale.ROOT);
 			float maxScore = (float) Arrays.stream(components)
 					.mapToDouble(name -> getScoreFor(ucTerm, name))
@@ -69,7 +74,7 @@ public class SearchUtil<T extends SearchEntry> {
 		 * Computes the score for the given <code>name</code> against the given search term.
 		 *
 		 * @param term the search term (expected to be upper-case)
-		 * @param name the entry name, split at word boundaries (see {@link SearchUtil#wordwiseSplit(String)})
+		 * @param name the entry name, split at word boundaries (see {@link Entry#wordwiseSplit(String)})
 		 * @return the computed score for the entry
 		 */
 		private static float getScoreFor(String term, String[] name) {
@@ -116,75 +121,75 @@ public class SearchUtil<T extends SearchEntry> {
 
 		public static <T extends SearchEntry> Entry<T> from(T e) {
 			String[][] components = e.getSearchableNames().parallelStream()
-					.map(SearchUtil::wordwiseSplit)
+					.map(Entry::wordwiseSplit)
 					.toArray(String[][]::new);
 			return new Entry<>(e, components);
 		}
 
-	}
-
-	private static int compareEqualLength(String s1, String s2) {
-		int len = 0;
-		while (len < s1.length() && len < s2.length() && s1.charAt(len) == s2.charAt(len)) {
-			len += 1;
-		}
-		return len;
-	}
-
-	/**
-	 * Splits the given input into components, trying to detect word parts.
-	 * <p>
-	 * Example of how words get split (using <code>|</code> as seperator):
-	 * <p><code>MinecraftClientGame -> Minecraft|Client|Game</code></p>
-	 * <p><code>HTTPInputStream -> HTTP|Input|Stream</code></p>
-	 * <p><code>class_932 -> class|_|932</code></p>
-	 * <p><code>X11FontManager -> X|11|Font|Manager</code></p>
-	 * <p><code>openHTTPConnection -> open|HTTP|Connection</code></p>
-	 * <p><code>open_http_connection -> open|_|http|_|connection</code></p>
-	 *
-	 * @param input the input to split
-	 * @return the resulting components
-	 */
-	private static String[] wordwiseSplit(String input) {
-		List<String> list = new ArrayList<>();
-		while (!input.isEmpty()) {
-			int take;
-			if (Character.isLetter(input.charAt(0))) {
-				if (input.length() == 1) {
-					take = 1;
-				} else {
-					boolean nextSegmentIsUppercase = Character.isUpperCase(input.charAt(0)) && Character.isUpperCase(input.charAt(1));
-					if (nextSegmentIsUppercase) {
-						int nextLowercase = 1;
-						while (Character.isUpperCase(input.charAt(nextLowercase))) {
-							nextLowercase += 1;
-							if (nextLowercase == input.length()) {
-								nextLowercase += 1;
-								break;
-							}
-						}
-						take = nextLowercase - 1;
-					} else {
-						int nextUppercase = 1;
-						while (nextUppercase < input.length() && Character.isLowerCase(input.charAt(nextUppercase))) {
-							nextUppercase += 1;
-						}
-						take = nextUppercase;
-					}
-				}
-			} else if (Character.isDigit(input.charAt(0))) {
-				int nextNonNum = 1;
-				while (nextNonNum < input.length() && Character.isLetter(input.charAt(nextNonNum)) && !Character.isLowerCase(input.charAt(nextNonNum))) {
-					nextNonNum += 1;
-				}
-				take = nextNonNum;
-			} else {
-				take = 1;
+		private static int compareEqualLength(String s1, String s2) {
+			int len = 0;
+			while (len < s1.length() && len < s2.length() && s1.charAt(len) == s2.charAt(len)) {
+				len += 1;
 			}
-			list.add(input.substring(0, take));
-			input = input.substring(take);
+			return len;
 		}
-		return list.toArray(new String[0]);
+
+		/**
+		 * Splits the given input into components, trying to detect word parts.
+		 * <p>
+		 * Example of how words get split (using <code>|</code> as seperator):
+		 * <p><code>MinecraftClientGame -> Minecraft|Client|Game</code></p>
+		 * <p><code>HTTPInputStream -> HTTP|Input|Stream</code></p>
+		 * <p><code>class_932 -> class|_|932</code></p>
+		 * <p><code>X11FontManager -> X|11|Font|Manager</code></p>
+		 * <p><code>openHTTPConnection -> open|HTTP|Connection</code></p>
+		 * <p><code>open_http_connection -> open|_|http|_|connection</code></p>
+		 *
+		 * @param input the input to split
+		 * @return the resulting components
+		 */
+		private static String[] wordwiseSplit(String input) {
+			List<String> list = new ArrayList<>();
+			while (!input.isEmpty()) {
+				int take;
+				if (Character.isLetter(input.charAt(0))) {
+					if (input.length() == 1) {
+						take = 1;
+					} else {
+						boolean nextSegmentIsUppercase = Character.isUpperCase(input.charAt(0)) && Character.isUpperCase(input.charAt(1));
+						if (nextSegmentIsUppercase) {
+							int nextLowercase = 1;
+							while (Character.isUpperCase(input.charAt(nextLowercase))) {
+								nextLowercase += 1;
+								if (nextLowercase == input.length()) {
+									nextLowercase += 1;
+									break;
+								}
+							}
+							take = nextLowercase - 1;
+						} else {
+							int nextUppercase = 1;
+							while (nextUppercase < input.length() && Character.isLowerCase(input.charAt(nextUppercase))) {
+								nextUppercase += 1;
+							}
+							take = nextUppercase;
+						}
+					}
+				} else if (Character.isDigit(input.charAt(0))) {
+					int nextNonNum = 1;
+					while (nextNonNum < input.length() && Character.isLetter(input.charAt(nextNonNum)) && !Character.isLowerCase(input.charAt(nextNonNum))) {
+						nextNonNum += 1;
+					}
+					take = nextNonNum;
+				} else {
+					take = 1;
+				}
+				list.add(input.substring(0, take));
+				input = input.substring(take);
+			}
+			return list.toArray(new String[0]);
+		}
+
 	}
 
 }

--- a/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
+++ b/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
@@ -136,7 +136,6 @@ public class SearchUtil<T extends SearchEntry> {
 	 * <p>
 	 * Example of how words get split (using <code>|</code> as seperator):
 	 * <p><code>MinecraftClientGame -> Minecraft|Client|Game</code></p>
-	 * <p><code>MinecraftClientGame -> Minecraft|Client|Game</code></p>
 	 * <p><code>HTTPInputStream -> HTTP|Input|Stream</code></p>
 	 * <p><code>class_932 -> class|_|932</code></p>
 	 * <p><code>X11FontManager -> X|11|Font|Manager</code></p>

--- a/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
+++ b/src/main/java/cuchaz/enigma/utils/search/SearchUtil.java
@@ -99,7 +99,7 @@ public class SearchUtil<T extends SearchEntry> {
 					for (int i = 1; i <= l; i++) {
 						float baseScore = scorePerChar * i;
 						float chainBonus = (i - 1) * 0.5f;
-						newSnapshots.put(remaining.substring(i), score + baseScore * posMultiplier + chainBonus);
+						merge(newSnapshots, Collections.singletonMap(remaining.substring(i), score + baseScore * posMultiplier + chainBonus), Math::max);
 					}
 				}
 				merge(snapshots, newSnapshots, Math::max);

--- a/src/main/resources/lang/en_us.json
+++ b/src/main/resources/lang/en_us.json
@@ -113,6 +113,8 @@
 	"prompt.close.save": "Save and close",
 	"prompt.close.discard": "Discard changes",
 	"prompt.close.cancel": "Cancel",
+	"prompt.open": "Open",
+	"prompt.cancel": "Cancel",
 
 	"crash.title": "%s - Crash Report",
 	"crash.summary": "%s has crashed! =(",


### PR DESCRIPTION
The search dialog has been completely broken for a while now so I rewrote the whole thing, UI included.

Internals changes: It now no longer uses an external library to do the search, but instead something that's as close to IntelliJ/Eclipse's search as I could get.

UI changes: The dialog is now persistent and will retain its last search term in the search box. The results list now includes the deobf name in addition to the obf name, and both names show the fully qualified name as a tooltip.

![image](https://user-images.githubusercontent.com/3987560/80233503-dd84d180-8656-11ea-8592-26af8a028093.png)