### PR TITLE
Fix circular class loading crash

### DIFF
--- a/src/main/java/cuchaz/enigma/config/Config.java
+++ b/src/main/java/cuchaz/enigma/config/Config.java
@@ -7,7 +7,6 @@ import cuchaz.enigma.source.DecompilerService;
 import cuchaz.enigma.source.Decompilers;
 
 import cuchaz.enigma.utils.I18n;
-import cuchaz.enigma.gui.util.ScaleUtil;
 
 import javax.swing.*;
 import javax.swing.plaf.metal.MetalLookAndFeel;
@@ -79,7 +78,7 @@ public class Config {
 		public static boolean isDarkLaf() {
 			// a bit of a hack because swing doesn't give any API for that, and we need colors that aren't defined in look and feel
 			JPanel panel = new JPanel();
-			panel.setSize(ScaleUtil.getDimension(10, 10));
+			panel.setSize(new Dimension(10, 10));
 			panel.doLayout();
 
 			BufferedImage image = new BufferedImage(panel.getSize().width, panel.getSize().height, BufferedImage.TYPE_INT_RGB);


### PR DESCRIPTION
This is what people have been getting, and it's apparently related to ScaleUtil.getDimension loading Config and Config calling ScaleUtil.getDimension

```
Exception in thread "main" java.lang.ExceptionInInitializerError
        at cuchaz.enigma.utils.I18n.<clinit>(I18n.java:29)
        at cuchaz.enigma.analysis.index.JarIndex.indexJar(JarIndex.java:64)
        at cuchaz.enigma.analysis.ClassCache.index(ClassCache.java:124)
        at cuchaz.enigma.Enigma.openJar(Enigma.java:49)
        at cuchaz.enigma.command.Command.openProject(Command.java:37)
        at cuchaz.enigma.command.DeobfuscateCommand.run(DeobfuscateCommand.java:30)
        at cuchaz.enigma.CommandMain.main(CommandMain.java:43)
Caused by: java.lang.NullPointerException
        at cuchaz.enigma.gui.util.ScaleUtil.getScaleFactor(ScaleUtil.java:25)
        at cuchaz.enigma.gui.util.ScaleUtil.scale(ScaleUtil.java:69)
        at cuchaz.enigma.gui.util.ScaleUtil.getDimension(ScaleUtil.java:49)
        at cuchaz.enigma.config.Config$LookAndFeel.isDarkLaf(Config.java:82)
        at cuchaz.enigma.config.Config$LookAndFeel.apply(Config.java:96)
        at cuchaz.enigma.config.Config.reset(Config.java:239)
        at cuchaz.enigma.config.Config.loadConfig(Config.java:227)
        at cuchaz.enigma.config.Config.<init>(Config.java:203)
        at cuchaz.enigma.config.Config.<clinit>(Config.java:159)
        ... 7 more
```