### PR TITLE
A quick and dirty workaround for not being able to add javadoc…

### DIFF
--- a/src/main/java/cuchaz/enigma/translation/mapping/MappingPair.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/MappingPair.java
@@ -6,7 +6,7 @@ import javax.annotation.Nullable;
 
 public class MappingPair<E extends Entry<?>, M> {
 	private final E entry;
-	private final M mapping;
+	private M mapping;
 
 	public MappingPair(E entry, @Nullable M mapping) {
 		this.entry = entry;
@@ -24,5 +24,9 @@ public class MappingPair<E extends Entry<?>, M> {
 	@Nullable
 	public M getMapping() {
 		return mapping;
+	}
+
+	public void setMapping(M mapping) {
+		this.mapping = mapping;
 	}
 }

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsReader.java
@@ -179,8 +179,9 @@ public enum EnigmaMappingsReader implements MappingsReader {
 			throw new IllegalStateException("Javadoc has no parent!");
 		// Empty string to concat
 		String jdLine = tokens.length > 1 ? String.join(" ", Arrays.copyOfRange(tokens,1,tokens.length))  : "";
-		if (parent.getMapping() == null)
-			throw new IllegalStateException("Javadoc requires a mapping!");
+		if (parent.getMapping() == null) {
+			parent.setMapping(new RawEntryMapping(parent.getEntry().getName(), AccessModifier.UNCHANGED));
+		}
 		parent.getMapping().addJavadocLine(MappingHelper.unescape(jdLine));
 	}
 
@@ -228,7 +229,10 @@ public enum EnigmaMappingsReader implements MappingsReader {
 		AccessModifier modifier = AccessModifier.UNCHANGED;
 		TypeDescriptor descriptor;
 
-		if (tokens.length == 4) {
+		if (tokens.length == 3) {
+			mapping = tokens[1];
+			descriptor = new TypeDescriptor(tokens[2]);
+		} else if (tokens.length == 4) {
 			AccessModifier parsedModifier = parseModifier(tokens[3]);
 			if (parsedModifier != null) {
 				descriptor = new TypeDescriptor(tokens[2]);

--- a/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
+++ b/src/main/java/cuchaz/enigma/translation/mapping/serde/EnigmaMappingsWriter.java
@@ -271,7 +271,9 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 	protected String writeMethod(MethodEntry entry, EntryMapping mapping) {
 		StringBuilder builder = new StringBuilder(EnigmaFormat.METHOD + " ");
 		builder.append(entry.getName()).append(' ');
-		writeMapping(builder, mapping);
+		if (mapping != null && !mapping.getTargetName().equals(entry.getName())) {
+			writeMapping(builder, mapping);
+		}
 
 		builder.append(entry.getDesc().toString());
 
@@ -281,7 +283,9 @@ public enum EnigmaMappingsWriter implements MappingsWriter {
 	protected String writeField(FieldEntry entry, EntryMapping mapping) {
 		StringBuilder builder = new StringBuilder(EnigmaFormat.FIELD + " ");
 		builder.append(entry.getName()).append(' ');
-		writeMapping(builder, mapping);
+		if (mapping != null && !mapping.getTargetName().equals(entry.getName())) {
+			writeMapping(builder, mapping);
+		}
 
 		builder.append(entry.getDesc().toString());
 


### PR DESCRIPTION
to methods or fields without a mapping (mainly none obf names)

This is a much less impactful PR, and not ideal but something that is needed.