### PR TITLE
Use MacOS menu bar style

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -126,6 +126,8 @@ public class Gui {
 			});
 		}
 
+		System.setProperty("apple.laf.useScreenMenuBar", "true");
+
 		this.controller = new GuiController(this, profile);
 
 		Themes.addListener((lookAndFeel, boxHighlightPainters) -> SwingUtilities.updateComponentTreeUI(getFrame()));


### PR DESCRIPTION
## Before:
<img width="513" alt="Screenshot 2020-06-05 at 20 22 27" src="https://user-images.githubusercontent.com/4324090/83915065-6de02700-a76a-11ea-8526-54c277a564b8.png">

## After:

<img width="1061" alt="Screenshot 2020-06-05 at 20 22 09" src="https://user-images.githubusercontent.com/4324090/83915070-720c4480-a76a-11ea-95ad-ce8cd1d9d8cb.png">

I tried to fix the name of the application, but failed to do so. this is the major improvement to mac os support.