### PR TITLE
Fix javadoc loss when renaming entry

### DIFF
--- a/enigma-server/src/main/java/cuchaz/enigma/network/packet/RenameC2SPacket.java
+++ b/enigma-server/src/main/java/cuchaz/enigma/network/packet/RenameC2SPacket.java
@@ -4,10 +4,10 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
+import cuchaz.enigma.network.Message;
 import cuchaz.enigma.network.ServerPacketHandler;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.entry.Entry;
-import cuchaz.enigma.network.Message;
 import cuchaz.enigma.utils.validation.PrintValidatable;
 import cuchaz.enigma.utils.validation.ValidationContext;
 
@@ -47,7 +47,8 @@ public class RenameC2SPacket implements Packet<ServerPacketHandler> {
 		boolean valid = handler.getServer().canModifyEntry(handler.getClient(), entry);
 
 		if (valid) {
-			handler.getServer().getMappings().mapFromObf(vc, entry, new EntryMapping(newName));
+			EntryMapping previous = handler.getServer().getMappings().getDeobfMapping(entry);
+			handler.getServer().getMappings().mapFromObf(vc, entry, previous != null ? previous.withName(newName) : new EntryMapping(newName));
 			valid = vc.canProceed();
 		}
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -28,6 +28,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
 import com.google.common.collect.Lists;
+
 import cuchaz.enigma.Enigma;
 import cuchaz.enigma.EnigmaProfile;
 import cuchaz.enigma.EnigmaProject;
@@ -422,7 +423,8 @@ public class GuiController implements ClientPacketHandler {
 
 	public void rename(ValidationContext vc, EntryReference<Entry<?>, Entry<?>> reference, String newName, boolean refreshClassTree, boolean validateOnly) {
 		Entry<?> entry = reference.getNameableEntry();
-		project.getMapper().mapFromObf(vc, entry, new EntryMapping(newName), true, validateOnly);
+		EntryMapping previous = project.getMapper().getDeobfMapping(entry);
+		project.getMapper().mapFromObf(vc, entry, previous != null ? previous.withName(newName) : new EntryMapping(newName), true, validateOnly);
 
 		if (validateOnly || !vc.canProceed()) return;
 


### PR DESCRIPTION
The entire entry setting API needs a more comprehensive overhaul since right now it's jank city, but this will do.

Closes #190.