### PR TITLE
Fix crash on remapping [T

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/TypeDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/TypeDescriptor.java
@@ -11,17 +11,18 @@
 
 package cuchaz.enigma.translation.representation;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import cuchaz.enigma.translation.Translatable;
-import cuchaz.enigma.translation.Translator;
-import cuchaz.enigma.translation.mapping.EntryMapping;
-import cuchaz.enigma.translation.mapping.EntryResolver;
-import cuchaz.enigma.translation.mapping.EntryMap;
-import cuchaz.enigma.translation.representation.entry.ClassEntry;
-
 import java.util.Map;
 import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMap;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.EntryResolver;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
 
 public class TypeDescriptor implements Translatable {
 
@@ -32,7 +33,7 @@ public class TypeDescriptor implements Translatable {
 
 		// don't deal with generics
 		// this is just for raw jvm types
-		if (desc.charAt(0) == 'T' || desc.indexOf('<') >= 0 || desc.indexOf('>') >= 0) {
+		if ((desc.charAt(0) == 'T' && readClass(desc) != null) || desc.indexOf('<') >= 0 || desc.indexOf('>') >= 0) {
 			throw new IllegalArgumentException("don't use with generic types or templates: " + desc);
 		}
 


### PR DESCRIPTION
Causes type descriptor to not crash when getting type parameter called `T` in arrays (but not `U`, etc.) by extending the generics check to actually check for a `;` afterwards (afaik actual type parameter types are `TT;`, `TU;`, ..., which is where that T comes from)

Closes #182.