### PR TITLE
Fix crash on remapping >1 level of nested class

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationSignatureVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationSignatureVisitor.java
@@ -1,10 +1,11 @@
 package cuchaz.enigma.bytecode.translators;
 
-import cuchaz.enigma.Enigma;
-import org.objectweb.asm.signature.SignatureVisitor;
-
 import java.util.Stack;
 import java.util.function.Function;
+
+import org.objectweb.asm.signature.SignatureVisitor;
+
+import cuchaz.enigma.Enigma;
 
 public class TranslationSignatureVisitor extends SignatureVisitor {
 	private final Function<String, String> remapper;
@@ -31,6 +32,7 @@ public class TranslationSignatureVisitor extends SignatureVisitor {
 		if (!name.startsWith(lastClass+"$")){//todo see if there's a way to base this on whether there were type params or not
 			name = lastClass+"$"+name;
 		}
+		classStack.push(name);
 		String translatedEntry = this.remapper.apply(name);
 		if (translatedEntry.contains("/")){
 			translatedEntry = translatedEntry.substring(translatedEntry.lastIndexOf("/")+1);


### PR DESCRIPTION
When there's 2 levels of inner classes, `visitInnerClassType` gets called twice... but it only ever calls `classStack.pop()`, never `push()`, so the stack is empty the next level of inner class.

This issue only occurs when exporting the server jar as source, since that includes all the server libraries, including classes like `Lit/unimi/dsi/fastutil/chars/Char2ObjectRBTreeMap<TV;>.Submap.SubmapIterator;`

Closes #119.