### PR TITLE
Fix "Mark as Deobfuscated" menu entry not working

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -646,9 +646,8 @@ public class Gui {
 		if (cursorReference == null) return;
 
 		Entry<?> obfEntry = cursorReference.entry;
-		Entry<?> deobfEntry = controller.project.getMapper().deobfuscate(obfEntry);
 
-		if (!Objects.equals(obfEntry, deobfEntry)) {
+		if (controller.project.getMapper().hasDeobfMapping(obfEntry)) {
 			if (!validateImmediateAction(vc -> this.controller.removeMapping(vc, cursorReference))) return;
 			this.controller.sendPacket(new RemoveMappingC2SPacket(cursorReference.getNameableEntry()));
 		} else {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
@@ -475,7 +475,7 @@ public class EditorPanel {
 		this.popupMenu.openNextMenu.setEnabled(this.controller.hasNextReference());
 		this.popupMenu.toggleMappingMenu.setEnabled(isRenamable);
 
-		if (referenceEntry != null && referenceEntry.equals(this.controller.project.getMapper().deobfuscate(referenceEntry))) {
+		if (referenceEntry != null && this.controller.project.getMapper().hasDeobfMapping(referenceEntry)) {
 			this.popupMenu.toggleMappingMenu.setText(I18n.translate("popup_menu.reset_obfuscated"));
 		} else {
 			this.popupMenu.toggleMappingMenu.setText(I18n.translate("popup_menu.mark_deobfuscated"));

--- a/enigma/src/main/java/cuchaz/enigma/source/DecompiledClassSource.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/DecompiledClassSource.java
@@ -51,7 +51,7 @@ public class DecompiledClassSource {
 		Entry<?> translatedEntry = translator.translate(entry);
 
 		if (project.isRenamable(reference)) {
-			if (isDeobfuscated(entry, translatedEntry)) {
+			if (project.getMapper().hasDeobfMapping(entry)) {
 				highlightToken(movedToken, RenamableTokenType.DEOBFUSCATED);
 				return translatedEntry.getSourceRemapName();
 			} else {
@@ -102,10 +102,6 @@ public class DecompiledClassSource {
 		}
 
 		return null;
-	}
-
-	private boolean isDeobfuscated(Entry<?> entry, Entry<?> translatedEntry) {
-		return !entry.getName().equals(translatedEntry.getName());
 	}
 
 	public ClassEntry getEntry() {


### PR DESCRIPTION
It didn't do anything because the obfuscated entry and deobfuscated entry are never the same if the outer class has a deobfuscated name.