### PR TITLE
Fix "Mark as Deobfuscated" menu entry not working... this time without breaking all the things hopefully

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     }
 
     group = 'cuchaz'
-    version = '0.19'
+    version = '0.20'
 
     def buildNumber = System.getenv("BUILD_NUMBER")
     version = version + "+" + (buildNumber ? "build.$buildNumber" : "local")

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -647,7 +647,7 @@ public class Gui {
 
 		Entry<?> obfEntry = cursorReference.entry;
 
-		if (controller.project.getMapper().hasDeobfMapping(obfEntry)) {
+		if (controller.project.getMapper().extendedDeobfuscate(obfEntry).isDeobfuscated()) {
 			if (!validateImmediateAction(vc -> this.controller.removeMapping(vc, cursorReference))) return;
 			this.controller.sendPacket(new RemoveMappingC2SPacket(cursorReference.getNameableEntry()));
 		} else {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
@@ -475,7 +475,7 @@ public class EditorPanel {
 		this.popupMenu.openNextMenu.setEnabled(this.controller.hasNextReference());
 		this.popupMenu.toggleMappingMenu.setEnabled(isRenamable);
 
-		if (referenceEntry != null && this.controller.project.getMapper().hasDeobfMapping(referenceEntry)) {
+		if (referenceEntry != null && this.controller.project.getMapper().extendedDeobfuscate(referenceEntry).isDeobfuscated()) {
 			this.popupMenu.toggleMappingMenu.setText(I18n.translate("popup_menu.reset_obfuscated"));
 		} else {
 			this.popupMenu.toggleMappingMenu.setText(I18n.translate("popup_menu.mark_deobfuscated"));

--- a/enigma/src/main/java/cuchaz/enigma/analysis/EntryReference.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/EntryReference.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
@@ -136,7 +137,8 @@ public class EntryReference<E extends Entry<?>, C extends Entry<?>> implements T
 	}
 
 	@Override
-	public Translatable translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
-		return new EntryReference<>(translator.translate(entry), translator.translate(context), this);
+	public TranslateResult<EntryReference<E, C>> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+		return translator.extendedTranslate(this.entry).map(e -> new EntryReference<>(e, translator.translate(context), this));
 	}
+
 }

--- a/enigma/src/main/java/cuchaz/enigma/source/DecompiledClassSource.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/DecompiledClassSource.java
@@ -9,6 +9,7 @@ import cuchaz.enigma.EnigmaServices;
 import cuchaz.enigma.analysis.EntryReference;
 import cuchaz.enigma.api.service.NameProposalService;
 import cuchaz.enigma.translation.LocalNameGenerator;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryRemapper;
 import cuchaz.enigma.translation.mapping.ResolutionStrategy;
@@ -48,12 +49,12 @@ public class DecompiledClassSource {
 		EntryReference<Entry<?>, Entry<?>> reference = obfuscatedIndex.getReference(token);
 
 		Entry<?> entry = reference.getNameableEntry();
-		Entry<?> translatedEntry = translator.translate(entry);
+		TranslateResult<Entry<?>> translatedEntry = translator.extendedTranslate(entry);
 
 		if (project.isRenamable(reference)) {
-			if (project.getMapper().hasDeobfMapping(entry)) {
-				highlightToken(movedToken, RenamableTokenType.DEOBFUSCATED);
-				return translatedEntry.getSourceRemapName();
+			if (!translatedEntry.isObfuscated()) {
+				highlightToken(movedToken, translatedEntry.getType());
+				return translatedEntry.getValue().getSourceRemapName();
 			} else {
 				Optional<String> proposedName = proposeName(project, entry);
 				if (proposedName.isPresent()) {
@@ -65,7 +66,7 @@ public class DecompiledClassSource {
 			}
 		}
 
-		String defaultName = generateDefaultName(translatedEntry);
+		String defaultName = generateDefaultName(translatedEntry.getValue());
 		if (defaultName != null) {
 			return defaultName;
 		}

--- a/enigma/src/main/java/cuchaz/enigma/translation/MappingTranslator.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/MappingTranslator.java
@@ -1,8 +1,10 @@
 package cuchaz.enigma.translation;
 
+import javax.annotation.Nullable;
+
+import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.EntryResolver;
-import cuchaz.enigma.translation.mapping.EntryMap;
 
 public class MappingTranslator implements Translator {
 	private final EntryMap<EntryMapping> mappings;
@@ -13,12 +15,14 @@ public class MappingTranslator implements Translator {
 		this.resolver = resolver;
 	}
 
+	@Nullable
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends Translatable> T translate(T translatable) {
+	public <T extends Translatable> TranslateResult<T> extendedTranslate(T translatable) {
 		if (translatable == null) {
 			return null;
 		}
-		return (T) translatable.translate(this, resolver, mappings);
+		return (TranslateResult<T>) translatable.extendedTranslate(this, resolver, mappings);
 	}
+
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/ProposingTranslator.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/ProposingTranslator.java
@@ -1,12 +1,14 @@
 package cuchaz.enigma.translation;
 
+import java.util.Arrays;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
 import cuchaz.enigma.api.service.NameProposalService;
 import cuchaz.enigma.translation.mapping.EntryRemapper;
 import cuchaz.enigma.translation.mapping.ResolutionStrategy;
 import cuchaz.enigma.translation.representation.entry.Entry;
-
-import java.util.Arrays;
-import java.util.Optional;
 
 public class ProposingTranslator implements Translator {
 	private final EntryRemapper mapper;
@@ -17,16 +19,16 @@ public class ProposingTranslator implements Translator {
 		this.nameProposalServices = nameProposalServices;
 	}
 
+	@Nullable
 	@Override
-	@SuppressWarnings("unchecked")
-	public <T extends Translatable> T translate(T translatable) {
+	public <T extends Translatable> TranslateResult<T> extendedTranslate(T translatable) {
 		if (translatable == null) {
 			return null;
 		}
 
-		T deobfuscated = mapper.deobfuscate(translatable);
+		TranslateResult<T> deobfuscated = mapper.extendedDeobfuscate(translatable);
 
-		if (translatable instanceof Entry && ((Entry) deobfuscated).getName().equals(((Entry<?>) translatable).getName())) {
+		if (translatable instanceof Entry && ((Entry) deobfuscated.getValue()).getName().equals(((Entry<?>) translatable).getName())) {
 			return mapper.getObfResolver()
 					.resolveEntry((Entry<?>) translatable, ResolutionStrategy.RESOLVE_ROOT)
 					.stream()
@@ -34,7 +36,7 @@ public class ProposingTranslator implements Translator {
 					.filter(Optional::isPresent)
 					.map(Optional::get)
 					.findFirst()
-					.map(newName -> (T) ((Entry) deobfuscated).withName(newName))
+					.map(newName -> TranslateResult.proposed((T) ((Entry) deobfuscated.getValue()).withName(newName)))
 					.orElse(deobfuscated);
 		}
 

--- a/enigma/src/main/java/cuchaz/enigma/translation/Translatable.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/Translatable.java
@@ -1,9 +1,16 @@
 package cuchaz.enigma.translation;
 
+import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.EntryResolver;
-import cuchaz.enigma.translation.mapping.EntryMap;
 
 public interface Translatable {
-	Translatable translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings);
+
+	TranslateResult<? extends Translatable> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings);
+
+	@Deprecated
+	default Translatable translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+		return this.extendedTranslate(translator, resolver, mappings).getValue();
+	}
+
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/TranslateResult.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/TranslateResult.java
@@ -1,0 +1,85 @@
+package cuchaz.enigma.translation;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import cuchaz.enigma.source.RenamableTokenType;
+
+public final class TranslateResult<T> {
+
+	private final RenamableTokenType type;
+	private final T value;
+
+	private TranslateResult(RenamableTokenType type, T value) {
+		this.type = type;
+		this.value = value;
+	}
+
+	public static <T> TranslateResult<T> of(RenamableTokenType type, T value) {
+		Objects.requireNonNull(type, "type must not be null");
+		return new TranslateResult<>(type, value);
+	}
+
+	// Used for translatables that don't have a concept of
+	// obfuscated/deobfuscated (e.g. method descriptors) for example because
+	// they don't have an identifier attached to them
+	public static <T> TranslateResult<T> ungrouped(T value) {
+		return TranslateResult.obfuscated(value);
+	}
+
+	public static <T> TranslateResult<T> obfuscated(T value) {
+		return TranslateResult.of(RenamableTokenType.OBFUSCATED, value);
+	}
+
+	public static <T> TranslateResult<T> deobfuscated(T value) {
+		return TranslateResult.of(RenamableTokenType.DEOBFUSCATED, value);
+	}
+
+	public static <T> TranslateResult<T> proposed(T value) {
+		return TranslateResult.of(RenamableTokenType.PROPOSED, value);
+	}
+
+	public RenamableTokenType getType() {
+		return type;
+	}
+
+	public T getValue() {
+		return value;
+	}
+
+	public <R> TranslateResult<R> map(Function<T, R> op) {
+		return TranslateResult.of(this.type, op.apply(this.value));
+	}
+
+	public boolean isObfuscated() {
+		return this.type == RenamableTokenType.OBFUSCATED;
+	}
+
+	public boolean isDeobfuscated() {
+		return this.type == RenamableTokenType.DEOBFUSCATED;
+	}
+
+	public boolean isProposed() {
+		return this.type == RenamableTokenType.PROPOSED;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		TranslateResult<?> that = (TranslateResult<?>) o;
+		return type == that.type &&
+				Objects.equals(value, that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(type, value);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TranslateResult { type: %s, value: %s }", type, value);
+	}
+
+}

--- a/enigma/src/main/java/cuchaz/enigma/translation/Translator.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/Translator.java
@@ -11,17 +11,27 @@
 
 package cuchaz.enigma.translation;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
 public interface Translator {
-	<T extends Translatable> T translate(T translatable);
+	@Nullable
+	<T extends Translatable> TranslateResult<T> extendedTranslate(@Nullable T translatable);
+
+	@Deprecated
+	@Nullable
+	default <T extends Translatable> T translate(@Nullable T translatable) {
+		TranslateResult<T> res = this.extendedTranslate(translatable);
+		return res == null ? null : res.getValue();
+	}
 
 	default <T extends Translatable> Collection<T> translate(Collection<T> translatable) {
 		return translatable.stream()

--- a/enigma/src/main/java/cuchaz/enigma/translation/VoidTranslator.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/VoidTranslator.java
@@ -4,7 +4,8 @@ public enum VoidTranslator implements Translator {
 	INSTANCE;
 
 	@Override
-	public <T extends Translatable> T translate(T translatable) {
-		return translatable;
+	public <T extends Translatable> TranslateResult<T> extendedTranslate(T translatable) {
+		return TranslateResult.obfuscated(translatable);
 	}
+
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/EntryRemapper.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.translation.MappingTranslator;
 import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.tree.DeltaTrackingTree;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
@@ -76,6 +77,10 @@ public class EntryRemapper {
 
 	public boolean hasDeobfMapping(Entry<?> obfEntry) {
 		return obfToDeobf.contains(obfEntry);
+	}
+
+	public <T extends Translatable> TranslateResult<T> extendedDeobfuscate(T translatable) {
+		return deobfuscator.extendedTranslate(translatable);
 	}
 
 	public <T extends Translatable> T deobfuscate(T translatable) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingDelta.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingDelta.java
@@ -49,7 +49,7 @@ public class MappingDelta<T> implements Translatable {
 	public TranslateResult<MappingDelta<T>> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
 		// there's no concept of deobfuscated for this as far as I can see, so
 		// it will always be marked as obfuscated
-		return TranslateResult.obfuscated(new MappingDelta<>(
+		return TranslateResult.ungrouped(new MappingDelta<>(
 				translator.translate(baseMappings),
 				translator.translate(changes)
 		));

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingDelta.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingDelta.java
@@ -1,13 +1,14 @@
 package cuchaz.enigma.translation.mapping;
 
+import java.util.stream.Stream;
+
 import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
 import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
 import cuchaz.enigma.translation.mapping.tree.HashEntryTree;
 import cuchaz.enigma.translation.representation.entry.Entry;
-
-import java.util.stream.Stream;
 
 public class MappingDelta<T> implements Translatable {
 	public static final Object PLACEHOLDER = new Object();
@@ -45,10 +46,12 @@ public class MappingDelta<T> implements Translatable {
 	}
 
 	@Override
-	public MappingDelta<T> translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
-		return new MappingDelta<>(
+	public TranslateResult<MappingDelta<T>> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+		// there's no concept of deobfuscated for this as far as I can see, so
+		// it will always be marked as obfuscated
+		return TranslateResult.obfuscated(new MappingDelta<>(
 				translator.translate(baseMappings),
 				translator.translate(changes)
-		);
+		));
 	}
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/tree/EntryTree.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/tree/EntryTree.java
@@ -1,15 +1,17 @@
 package cuchaz.enigma.translation.mapping.tree;
 
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
 import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.EntryResolver;
 import cuchaz.enigma.translation.representation.entry.Entry;
-
-import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.stream.Stream;
 
 public interface EntryTree<T> extends EntryMap<T>, Iterable<EntryTreeNode<T>>, Translatable {
 	Collection<Entry<?>> getChildren(Entry<?> entry);
@@ -20,6 +22,11 @@ public interface EntryTree<T> extends EntryMap<T>, Iterable<EntryTreeNode<T>>, T
 	EntryTreeNode<T> findNode(Entry<?> entry);
 
 	Stream<EntryTreeNode<T>> getRootNodes();
+
+	@Override
+	default TranslateResult<? extends EntryTree<T>> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+		return TranslateResult.ungrouped(this.translate(translator, resolver, mappings));
+	}
 
 	@Override
 	EntryTree<T> translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings);

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/Lambda.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/Lambda.java
@@ -1,6 +1,10 @@
 package cuchaz.enigma.translation.representation;
 
+import java.util.Objects;
+
+import cuchaz.enigma.source.RenamableTokenType;
 import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
@@ -9,8 +13,6 @@ import cuchaz.enigma.translation.mapping.ResolutionStrategy;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
 import cuchaz.enigma.translation.representation.entry.ParentedEntry;
-
-import java.util.Objects;
 
 public class Lambda implements Translatable {
 	private final String invokedName;
@@ -28,16 +30,19 @@ public class Lambda implements Translatable {
 	}
 
 	@Override
-	public Lambda translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+	public TranslateResult<Lambda> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
 		MethodEntry samMethod = new MethodEntry(getInterface(), invokedName, samMethodType);
 		EntryMapping samMethodMapping = resolveMapping(resolver, mappings, samMethod);
 
-		return new Lambda(
-			samMethodMapping != null ? samMethodMapping.getTargetName() : invokedName,
-			invokedType.translate(translator, resolver, mappings),
-			samMethodType.translate(translator, resolver, mappings),
-			implMethod.translate(translator, resolver, mappings),
-			instantiatedMethodType.translate(translator, resolver, mappings)
+		return TranslateResult.of(
+				samMethodMapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new Lambda(
+						samMethodMapping != null ? samMethodMapping.getTargetName() : invokedName,
+						invokedType.extendedTranslate(translator, resolver, mappings).getValue(),
+						samMethodType.extendedTranslate(translator, resolver, mappings).getValue(),
+						implMethod.extendedTranslate(translator, resolver, mappings).getValue(),
+						instantiatedMethodType.extendedTranslate(translator, resolver, mappings).getValue()
+				)
 		);
 	}
 
@@ -81,10 +86,10 @@ public class Lambda implements Translatable {
 		if (o == null || getClass() != o.getClass()) return false;
 		Lambda lambda = (Lambda) o;
 		return Objects.equals(invokedName, lambda.invokedName) &&
-			Objects.equals(invokedType, lambda.invokedType) &&
-			Objects.equals(samMethodType, lambda.samMethodType) &&
-			Objects.equals(implMethod, lambda.implMethod) &&
-			Objects.equals(instantiatedMethodType, lambda.instantiatedMethodType);
+				Objects.equals(invokedType, lambda.invokedType) &&
+				Objects.equals(samMethodType, lambda.samMethodType) &&
+				Objects.equals(implMethod, lambda.implMethod) &&
+				Objects.equals(instantiatedMethodType, lambda.instantiatedMethodType);
 	}
 
 	@Override
@@ -95,11 +100,11 @@ public class Lambda implements Translatable {
 	@Override
 	public String toString() {
 		return "Lambda{" +
-			"invokedName='" + invokedName + '\'' +
-			", invokedType=" + invokedType +
-			", samMethodType=" + samMethodType +
-			", implMethod=" + implMethod +
-			", instantiatedMethodType=" + instantiatedMethodType +
-			'}';
+				"invokedName='" + invokedName + '\'' +
+				", invokedType=" + invokedType +
+				", samMethodType=" + samMethodType +
+				", implMethod=" + implMethod +
+				", instantiatedMethodType=" + instantiatedMethodType +
+				'}';
 	}
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
@@ -11,18 +11,20 @@
 
 package cuchaz.enigma.translation.representation;
 
-import com.google.common.collect.Lists;
-import cuchaz.enigma.translation.Translatable;
-import cuchaz.enigma.translation.Translator;
-import cuchaz.enigma.translation.mapping.EntryMapping;
-import cuchaz.enigma.translation.mapping.EntryResolver;
-import cuchaz.enigma.translation.mapping.EntryMap;
-import cuchaz.enigma.translation.representation.entry.ClassEntry;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
+
+import com.google.common.collect.Lists;
+
+import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMap;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.EntryResolver;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
 
 public class MethodDescriptor implements Translatable {
 
@@ -118,12 +120,12 @@ public class MethodDescriptor implements Translatable {
 	}
 
 	@Override
-	public MethodDescriptor translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+	public TranslateResult<MethodDescriptor> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
 		List<TypeDescriptor> translatedArguments = new ArrayList<>(argumentDescs.size());
 		for (TypeDescriptor argument : argumentDescs) {
 			translatedArguments.add(translator.translate(argument));
 		}
-		return new MethodDescriptor(translatedArguments, translator.translate(returnDesc));
+		return TranslateResult.ungrouped(new MethodDescriptor(translatedArguments, translator.translate(returnDesc)));
 	}
 
 	public boolean canConflictWith(MethodDescriptor descriptor) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/Signature.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/Signature.java
@@ -1,18 +1,20 @@
 package cuchaz.enigma.translation.representation;
 
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.signature.SignatureWriter;
+
 import cuchaz.enigma.bytecode.translators.TranslationSignatureVisitor;
 import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.EntryResolver;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
-import org.objectweb.asm.signature.SignatureReader;
-import org.objectweb.asm.signature.SignatureVisitor;
-import org.objectweb.asm.signature.SignatureWriter;
-
-import java.util.function.Function;
-import java.util.regex.Pattern;
 
 public class Signature implements Translatable {
 	private static final Pattern OBJECT_PATTERN = Pattern.compile(".*:Ljava/lang/Object;:.*");
@@ -92,7 +94,8 @@ public class Signature implements Translatable {
 	}
 
 	@Override
-	public Translatable translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
-		return remap(name -> translator.translate(new ClassEntry(name)).getFullName());
+	public TranslateResult<Signature> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+		return TranslateResult.ungrouped(this.remap(name -> translator.translate(new ClassEntry(name)).getFullName()));
 	}
+
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/TypeDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/TypeDescriptor.java
@@ -11,17 +11,19 @@
 
 package cuchaz.enigma.translation.representation;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import cuchaz.enigma.translation.Translatable;
-import cuchaz.enigma.translation.Translator;
-import cuchaz.enigma.translation.mapping.EntryMapping;
-import cuchaz.enigma.translation.mapping.EntryResolver;
-import cuchaz.enigma.translation.mapping.EntryMap;
-import cuchaz.enigma.translation.representation.entry.ClassEntry;
-
 import java.util.Map;
 import java.util.function.Function;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+
+import cuchaz.enigma.translation.Translatable;
+import cuchaz.enigma.translation.TranslateResult;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMap;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.EntryResolver;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
 
 public class TypeDescriptor implements Translatable {
 
@@ -228,8 +230,8 @@ public class TypeDescriptor implements Translatable {
 	}
 
 	@Override
-	public Translatable translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
-		return remap(name -> translator.translate(new ClassEntry(name)).getFullName());
+	public TranslateResult<TypeDescriptor> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+		return TranslateResult.ungrouped(this.remap(name -> translator.translate(new ClassEntry(name)).getFullName()));
 	}
 
 	public enum Primitive {

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassDefEntry.java
@@ -11,14 +11,18 @@
 
 package cuchaz.enigma.translation.representation.entry;
 
+import java.util.Arrays;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.Signature;
-
-import javax.annotation.Nullable;
-import java.util.Arrays;
 
 public class ClassDefEntry extends ClassEntry implements DefEntry<ClassEntry> {
 	private final AccessFlags access;
@@ -71,14 +75,17 @@ public class ClassDefEntry extends ClassEntry implements DefEntry<ClassEntry> {
 	}
 
 	@Override
-	public ClassDefEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	public TranslateResult<ClassDefEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		Signature translatedSignature = translator.translate(signature);
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		AccessFlags translatedAccess = mapping != null ? mapping.getAccessModifier().transform(access) : access;
 		ClassEntry translatedSuper = translator.translate(superClass);
 		ClassEntry[] translatedInterfaces = Arrays.stream(interfaces).map(translator::translate).toArray(ClassEntry[]::new);
 		String docs = mapping != null ? mapping.getJavadoc() : null;
-		return new ClassDefEntry(parent, translatedName, translatedSignature, translatedAccess, translatedSuper, translatedInterfaces, docs);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new ClassDefEntry(parent, translatedName, translatedSignature, translatedAccess, translatedSuper, translatedInterfaces, docs)
+		);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -64,7 +64,7 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 	}
 
 	@Override
-	public TranslateResult<ClassEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
+	public TranslateResult<? extends ClassEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		if (name.charAt(0) == '[') {
 			TranslateResult<TypeDescriptor> translatedName = translator.extendedTranslate(new TypeDescriptor(name));
 			return translatedName.map(desc -> new ClassEntry(parent, desc.toString()));

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -17,6 +17,8 @@ import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.IdentifierValidation;
@@ -62,15 +64,18 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 	}
 
 	@Override
-	public ClassEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	public TranslateResult<ClassEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		if (name.charAt(0) == '[') {
-			String translatedName = translator.translate(new TypeDescriptor(name)).toString();
-			return new ClassEntry(parent, translatedName);
+			TranslateResult<TypeDescriptor> translatedName = translator.extendedTranslate(new TypeDescriptor(name));
+			return translatedName.map(desc -> new ClassEntry(parent, desc.toString()));
 		}
 
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		String docs = mapping != null ? mapping.getJavadoc() : null;
-		return new ClassEntry(parent, translatedName, docs);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new ClassEntry(parent, translatedName, docs)
+		);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldDefEntry.java
@@ -11,14 +11,17 @@
 
 package cuchaz.enigma.translation.representation.entry;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.Signature;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
-
-import javax.annotation.Nullable;
 
 public class FieldDefEntry extends FieldEntry implements DefEntry<ClassEntry> {
 	private final AccessFlags access;
@@ -50,14 +53,18 @@ public class FieldDefEntry extends FieldEntry implements DefEntry<ClassEntry> {
 	}
 
 	@Override
-	public FieldDefEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	protected TranslateResult<FieldEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		TypeDescriptor translatedDesc = translator.translate(desc);
 		Signature translatedSignature = translator.translate(signature);
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		AccessFlags translatedAccess = mapping != null ? mapping.getAccessModifier().transform(access) : access;
 		String docs = mapping != null ? mapping.getJavadoc() : null;
-		return new FieldDefEntry(parent, translatedName, translatedDesc, translatedSignature, translatedAccess, docs);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new FieldDefEntry(parent, translatedName, translatedDesc, translatedSignature, translatedAccess, docs)
+		);
 	}
+
 
 	@Override
 	public FieldDefEntry withName(String name) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
@@ -11,13 +11,17 @@
 
 package cuchaz.enigma.translation.representation.entry;
 
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
-
-import javax.annotation.Nullable;
-import java.util.Objects;
 
 public class FieldEntry extends ParentedEntry<ClassEntry> implements Comparable<FieldEntry> {
 	protected final TypeDescriptor desc;
@@ -59,10 +63,13 @@ public class FieldEntry extends ParentedEntry<ClassEntry> implements Comparable<
 	}
 
 	@Override
-	protected FieldEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	protected TranslateResult<FieldEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		String docs = mapping != null ? mapping.getJavadoc() : null;
-		return new FieldEntry(parent, translatedName, translator.translate(desc), docs);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new FieldEntry(parent, translatedName, translator.translate(desc), docs)
+		);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/LocalVariableDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/LocalVariableDefEntry.java
@@ -1,11 +1,14 @@
 package cuchaz.enigma.translation.representation.entry;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
-
-import javax.annotation.Nullable;
 
 /**
  * TypeDescriptor...
@@ -27,11 +30,14 @@ public class LocalVariableDefEntry extends LocalVariableEntry {
 	}
 
 	@Override
-	public LocalVariableDefEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	protected TranslateResult<LocalVariableEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		TypeDescriptor translatedDesc = translator.translate(desc);
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		String javadoc = mapping != null ? mapping.getJavadoc() : javadocs;
-		return new LocalVariableDefEntry(parent, index, translatedName, parameter, translatedDesc, javadoc);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new LocalVariableDefEntry(parent, index, translatedName, parameter, translatedDesc, javadoc)
+		);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/LocalVariableEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/LocalVariableEntry.java
@@ -1,11 +1,15 @@
 package cuchaz.enigma.translation.representation.entry;
 
-import com.google.common.base.Preconditions;
-import cuchaz.enigma.translation.Translator;
-import cuchaz.enigma.translation.mapping.EntryMapping;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
-import java.util.Objects;
+
+import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMapping;
 
 /**
  * TypeDescriptor...
@@ -46,10 +50,13 @@ public class LocalVariableEntry extends ParentedEntry<MethodEntry> implements Co
 	}
 
 	@Override
-	public LocalVariableEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	protected TranslateResult<LocalVariableEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		String javadoc = mapping != null ? mapping.getJavadoc() : null;
-		return new LocalVariableEntry(parent, index, translatedName, parameter, javadoc);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new LocalVariableEntry(parent, index, translatedName, parameter, javadoc)
+		);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodDefEntry.java
@@ -11,14 +11,17 @@
 
 package cuchaz.enigma.translation.representation.entry;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.MethodDescriptor;
 import cuchaz.enigma.translation.representation.Signature;
-
-import javax.annotation.Nullable;
 
 public class MethodDefEntry extends MethodEntry implements DefEntry<ClassEntry> {
 	private final AccessFlags access;
@@ -50,13 +53,16 @@ public class MethodDefEntry extends MethodEntry implements DefEntry<ClassEntry> 
 	}
 
 	@Override
-	public MethodDefEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	protected TranslateResult<MethodDefEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		MethodDescriptor translatedDesc = translator.translate(descriptor);
 		Signature translatedSignature = translator.translate(signature);
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		AccessFlags translatedAccess = mapping != null ? mapping.getAccessModifier().transform(access) : access;
 		String docs = mapping != null ? mapping.getJavadoc() : null;
-		return new MethodDefEntry(parent, translatedName, translatedDesc, translatedSignature, translatedAccess, docs);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new MethodDefEntry(parent, translatedName, translatedDesc, translatedSignature, translatedAccess, docs)
+		);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodEntry.java
@@ -58,7 +58,7 @@ public class MethodEntry extends ParentedEntry<ClassEntry> implements Comparable
 	}
 
 	@Override
-	protected TranslateResult<MethodEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
+	protected TranslateResult<? extends MethodEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		String docs = mapping != null ? mapping.getJavadoc() : null;
 		return TranslateResult.of(

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodEntry.java
@@ -11,13 +11,17 @@
 
 package cuchaz.enigma.translation.representation.entry;
 
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.source.RenamableTokenType;
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.MethodDescriptor;
-
-import javax.annotation.Nullable;
-import java.util.Objects;
 
 public class MethodEntry extends ParentedEntry<ClassEntry> implements Comparable<MethodEntry> {
 
@@ -54,10 +58,13 @@ public class MethodEntry extends ParentedEntry<ClassEntry> implements Comparable
 	}
 
 	@Override
-	public MethodEntry translate(Translator translator, @Nullable EntryMapping mapping) {
+	protected TranslateResult<MethodEntry> extendedTranslate(Translator translator, @Nullable EntryMapping mapping) {
 		String translatedName = mapping != null ? mapping.getTargetName() : name;
 		String docs = mapping != null ? mapping.getJavadoc() : null;
-		return new MethodEntry(parent, translatedName, translator.translate(descriptor), docs);
+		return TranslateResult.of(
+				mapping == null ? RenamableTokenType.OBFUSCATED : RenamableTokenType.DEOBFUSCATED,
+				new MethodEntry(parent, translatedName, translator.translate(descriptor), docs)
+		);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
@@ -11,14 +11,16 @@
 
 package cuchaz.enigma.translation.representation.entry;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Preconditions;
+
+import cuchaz.enigma.translation.TranslateResult;
 import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.EntryResolver;
 import cuchaz.enigma.translation.mapping.ResolutionStrategy;
-
-import javax.annotation.Nullable;
 
 public abstract class ParentedEntry<P extends Entry<?>> implements Entry<P> {
 	protected final P parent;
@@ -39,7 +41,12 @@ public abstract class ParentedEntry<P extends Entry<?>> implements Entry<P> {
 	@Override
 	public abstract ParentedEntry<P> withName(String name);
 
-	protected abstract ParentedEntry<P> translate(Translator translator, @Nullable EntryMapping mapping);
+	protected abstract TranslateResult<? extends ParentedEntry<P>> extendedTranslate(Translator translator, @Nullable EntryMapping mapping);
+
+	@Deprecated
+	protected ParentedEntry<P> translate(Translator translator, @Nullable EntryMapping mapping)  {
+		return this.extendedTranslate(translator, mapping).getValue();
+	}
 
 	@Override
 	public String getName() {
@@ -59,14 +66,14 @@ public abstract class ParentedEntry<P extends Entry<?>> implements Entry<P> {
 	}
 
 	@Override
-	public ParentedEntry<P> translate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
+	public TranslateResult<? extends ParentedEntry<P>> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
 		P parent = getParent();
 		EntryMapping mapping = resolveMapping(resolver, mappings);
 		if (parent == null) {
-			return translate(translator, mapping);
+			return this.extendedTranslate(translator, mapping);
 		}
 		P translatedParent = translator.translate(parent);
-		return withParent(translatedParent).translate(translator, mapping);
+		return this.withParent(translatedParent).extendedTranslate(translator, mapping);
 	}
 
 	private EntryMapping resolveMapping(EntryResolver resolver, EntryMap<EntryMapping> mappings) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
@@ -43,11 +43,6 @@ public abstract class ParentedEntry<P extends Entry<?>> implements Entry<P> {
 
 	protected abstract TranslateResult<? extends ParentedEntry<P>> extendedTranslate(Translator translator, @Nullable EntryMapping mapping);
 
-	@Deprecated
-	protected ParentedEntry<P> translate(Translator translator, @Nullable EntryMapping mapping)  {
-		return this.extendedTranslate(translator, mapping).getValue();
-	}
-
 	@Override
 	public String getName() {
 		return name;


### PR DESCRIPTION
See https://github.com/FabricMC/Enigma/commit/142b463faaad94f9fe8e33fe753ae5845b975ac6#r40131098

Previously, deobfuscate()/translate() and compare against obfuscated mapping was used to determine if a mapping was deobfuscated or not (for highlighting purposes). In #265 I changed this to use hasDeobfMapping because the previous equality check would never succeed for methods in classes with deobfuscated names, since it would compare against the whole thing, including the outer class name. Unfortunately the fix in #265 fails for overrides in subclasses because the mapping is in the superclass, and hasDeobfMapping doesn't check for that.

This adds extendedTranslate to Translatable, which, in addition to the resulting name, returns whether the returned name is deobfuscated, obfuscated or proposed (RenamableTokenType enum). This should also prevent needing to manually check whether an entry is deobfuscated or not in addition to translating, since this information is already returned by extendedTranslate.