### PR TITLE
Fix array classes not being translated correctly

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -184,6 +184,10 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 
 	@Nullable
 	public static ClassEntry getOuterClass(String name) {
+		if (name.charAt(0) == '[') {
+			return null;
+		}
+
 		int index = name.lastIndexOf('$');
 		if (index >= 0) {
 			return new ClassEntry(name.substring(0, index));
@@ -192,6 +196,10 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 	}
 
 	public static String getInnerName(String name) {
+		if (name.charAt(0) == '[') {
+			return name;
+		}
+
 		int innerClassPos = name.lastIndexOf('$');
 		if (innerClassPos > 0) {
 			return name.substring(innerClassPos + 1);


### PR DESCRIPTION
Currently, an array class such as `[LOuter$Inner;` would not get translated correctly because `new ClassEntry("[LOuter$Inner;")` calls `new ClassEntry("[LOuter", "Inner;")`, as if `Inner;` was an inner class of the parent class `[LOuter`. This PR fixes the parent class check to avoid this problem. (also see https://github.com/FabricMC/Enigma/pull/173)