### PR TITLE
Allows setting the default editor font in the configuration file

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/EnigmaSyntaxKit.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/EnigmaSyntaxKit.java
@@ -52,6 +52,10 @@ public class EnigmaSyntaxKit extends JavaSyntaxKit {
         configuration.put("RightMarginColumn", "999"); //No need to have a right margin, if someone wants it add a config
 
         configuration.put("Action.quick-find", "cuchaz.enigma.gui.QuickFindAction, menu F");
+
+        if (Config.getInstance().editorFont != null) {
+            configuration.put("DefaultFont", Config.getInstance().editorFont);
+        }
     }
 
     /**

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/Config.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/Config.java
@@ -166,6 +166,8 @@ public class Config {
 	public AlphaColorEntry deobfuscatedColor;
 	public AlphaColorEntry deobfuscatedColorOutline;
 
+	public String editorFont;
+
 	public Integer editorBackground;
 	public Integer highlightColor;
 	public Integer caretColor;


### PR DESCRIPTION
_I am old, I need big font :-|_

I didn't add a Dialog to set this because it seems like Swing has no default Font selection dialog.

So the only way to set it is to go to the config-file and enter it manually. For example: "Consolas-14".