### PR TITLE
Fix losing current cursor position when renaming entries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     }
 
     group = 'cuchaz'
-    version = '0.20'
+    version = '0.21'
 
     def buildNumber = System.getenv("BUILD_NUMBER")
     version = version + "+" + (buildNumber ? "build.$buildNumber" : "local")

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
@@ -561,6 +561,7 @@ public class EditorPanel {
 
 		if (this.nextReference != null) {
 			this.showReference0(this.nextReference);
+			this.nextReference = null;
 		}
 	}
 

--- a/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
@@ -11,10 +11,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nullable;
 
+import cuchaz.enigma.EnigmaProject;
 import cuchaz.enigma.classprovider.CachingClassProvider;
 import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
-
-import cuchaz.enigma.EnigmaProject;
 import cuchaz.enigma.events.ClassHandleListener;
 import cuchaz.enigma.events.ClassHandleListener.InvalidationType;
 import cuchaz.enigma.source.*;
@@ -277,8 +276,8 @@ public final class ClassHandleProvider {
 				if (res == null || mappedVersion.get() != v) return;
 				res = res.andThen(source -> {
 					try {
-						source.remapSource(p.project, p.project.getMapper().getDeobfuscator());
-						return Result.ok(source);
+						DecompiledClassSource remappedSource = source.remapSource(p.project, p.project.getMapper().getDeobfuscator());
+						return Result.ok(remappedSource);
 					} catch (Throwable e) {
 						return Result.err(ClassHandleError.remap(e));
 					}

--- a/enigma/src/main/java/cuchaz/enigma/source/Token.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/Token.java
@@ -23,9 +23,12 @@ public class Token implements Comparable<Token> {
 		this.text = text;
 	}
 
+	public int length() {
+		return this.end - this.start;
+	}
+
 	public int getRenameOffset(String to) {
-		int length = this.end - this.start;
-		return to.length() - length;
+		return to.length() - this.length();
 	}
 
 	public void rename(StringBuffer source, String to) {

--- a/enigma/src/main/java/cuchaz/enigma/source/TokenStore.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/TokenStore.java
@@ -1,0 +1,71 @@
+package cuchaz.enigma.source;
+
+import java.util.*;
+
+public final class TokenStore {
+
+	private static final TokenStore EMPTY = new TokenStore(Collections.emptyNavigableSet(), Collections.emptyMap(), null);
+
+	private final NavigableSet<Token> tokens;
+	private final Map<RenamableTokenType, NavigableSet<Token>> byType;
+	private final String obfSource;
+
+	private TokenStore(NavigableSet<Token> tokens, Map<RenamableTokenType, NavigableSet<Token>> byType, String obfSource) {
+		this.tokens = tokens;
+		this.byType = byType;
+		this.obfSource = obfSource;
+	}
+
+	public static TokenStore create(SourceIndex obfuscatedIndex) {
+		EnumMap<RenamableTokenType, NavigableSet<Token>> map = new EnumMap<>(RenamableTokenType.class);
+		for (RenamableTokenType value : RenamableTokenType.values()) {
+			map.put(value, new TreeSet<>(Comparator.comparing(t -> t.start)));
+		}
+		return new TokenStore(new TreeSet<>(Comparator.comparing(t -> t.start)), Collections.unmodifiableMap(map), obfuscatedIndex.getSource());
+	}
+
+	public static TokenStore empty() {
+		return TokenStore.EMPTY;
+	}
+
+	public void add(RenamableTokenType type, Token token) {
+		this.tokens.add(token);
+		this.byType.get(type).add(token);
+	}
+
+	public boolean isCompatible(TokenStore other) {
+		return this.obfSource != null && other.obfSource != null &&
+				this.obfSource.equals(other.obfSource) &&
+				this.tokens.size() == other.tokens.size();
+	}
+
+	public int mapPosition(TokenStore to, int position) {
+		if (!this.isCompatible(to)) return 0;
+
+		int newPos = position;
+		Iterator<Token> thisIter = this.tokens.iterator();
+		Iterator<Token> toIter = to.tokens.iterator();
+		while (thisIter.hasNext()) {
+			Token token = thisIter.next();
+			Token newToken = toIter.next();
+
+			if (position < token.start) break;
+
+			// if we're inside the token and the text changed,
+			// snap the cursor to the beginning
+			if (!token.text.equals(newToken.text) && position < token.end) {
+				newPos = newToken.start;
+				break;
+			}
+
+			newPos += newToken.length() - token.length();
+		}
+
+		return newPos;
+	}
+
+	public Map<RenamableTokenType, NavigableSet<Token>> getByType() {
+		return byType;
+	}
+
+}


### PR DESCRIPTION
In multiplayer, someone else renaming an entry would cause the cursor to be reset to the end of the file if there was no token selected. This fixes that by going through the length of all the tokens before the cursor and moving it by how much the length of the token has changed.