### PR TITLE
Set config path to Application Support on mac

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/config/ConfigPaths.java
+++ b/enigma/src/main/java/cuchaz/enigma/config/ConfigPaths.java
@@ -21,7 +21,7 @@ public class ConfigPaths {
 				}
 				return Paths.get(configHome);
 			case MAC:
-				return getUserHomeUnix().resolve("Library").resolve("Preferences");
+				return getUserHomeUnix().resolve("Library").resolve("Application Support");
 			case WINDOWS:
 				return Paths.get(System.getenv("LOCALAPPDATA"));
 			default:


### PR DESCRIPTION
`~/Library/Preferences` is for `.plist` files created by `.app` applications