### PR TITLE
Fixed package renaming

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     }
 
     group = 'cuchaz'
-    version = '0.21'
+    version = '0.21.1'
 
     def buildNumber = System.getenv("BUILD_NUMBER")
     version = version + "+" + (buildNumber ? "build.$buildNumber" : "local")

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -747,10 +747,8 @@ public class Gui implements LanguageChangeListener {
 				DefaultMutableTreeNode childNode = (DefaultMutableTreeNode) node.getChildAt(i);
 				ClassEntry prevDataChild = (ClassEntry) childNode.getUserObject();
 				ClassEntry dataChild = new ClassEntry(data + "/" + prevDataChild.getSimpleName());
-				this.controller.rename(vc, new EntryReference<>(prevDataChild, prevDataChild.getFullName()), dataChild.getFullName(), false);
-				if (!vc.canProceed()) return;
-				this.controller.sendPacket(new RenameC2SPacket(prevDataChild, dataChild.getFullName(), false));
-				childNode.setUserObject(dataChild);
+
+				onPanelRename(vc, prevDataChild, dataChild, node);
 			}
 			node.setUserObject(data);
 			// Ob package will never be modified, just reload deob view


### PR DESCRIPTION
It's possible to rename an entire package at once by pressing F2 in the deobf panel, but it resulted in invalid mapping files. This PR fixes that

Closes #304 