### PR TITLE
Do not abort decompile command on decompiler errors

### DIFF
--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
@@ -2,6 +2,7 @@ package cuchaz.enigma.command;
 
 import cuchaz.enigma.EnigmaProject;
 import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.EnigmaProject.DecompileErrorStrategy;
 import cuchaz.enigma.source.DecompilerService;
 import cuchaz.enigma.source.Decompilers;
 
@@ -47,7 +48,7 @@ public class DecompileCommand extends Command {
 		ProgressListener progress = new ConsoleProgressListener();
 
 		EnigmaProject.JarExport jar = project.exportRemappedJar(progress);
-		EnigmaProject.SourceExport source = jar.decompile(progress, decompilerService);
+		EnigmaProject.SourceExport source = jar.decompile(progress, decompilerService, DecompileErrorStrategy.TRACE_AS_SOURCE);
 
 		source.write(fileJarOut, progress);
 	}

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -216,10 +216,6 @@ public class EnigmaProject {
 			}
 		}
 
-		public SourceExport decompile(ProgressListener progress, DecompilerService decompilerService) {
-			return this.decompile(progress, decompilerService, DecompileErrorStrategy.PROPAGATE);
-		}
-
 		public SourceExport decompile(ProgressListener progress, DecompilerService decompilerService, DecompileErrorStrategy errorStrategy) {
 			List<ClassSource> decompiled = this.decompileStream(progress, decompilerService, errorStrategy).collect(Collectors.toList());
 			return new SourceExport(decompiled);


### PR DESCRIPTION
As explained in PR #289, the decompilers may fail decompiling some vanilla Minecraft classes. Although it is my opinion that these errors should be fixed in the decompilers themselves, currently they render the decompile CLI command useless, as no output is produced whatsoever.

The PR that was mentioned previously addressed this situation for the GUI part of Enigma, but not for the CLI commands, which were left untouched.

These changes modify the decompiler error strategy used by the aforementioned CLI command to trace the errors, but continue decompiling classes, so at least a partial output is generated. This way users will be happy that the Enigma decompile command works, and developers will still be motivated to fix the underlying issues.