### PR TITLE
Improvements to deobf panel popup menu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     }
 
     group = 'cuchaz'
-    version = '0.21.5'
+    version = '0.21.6'
 
     def buildNumber = System.getenv("BUILD_NUMBER")
     version = version + "+" + (buildNumber ? "build.$buildNumber" : "local")

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -301,9 +301,6 @@ public class Gui implements LanguageChangeListener {
 						deobfPanelPopupMenu.show(deobfPanel.deobfClasses, e.getX(), e.getY());
 					}
 				}
-
-				// Only enable rename class if selected path is a class
-				deobfPanelPopupMenu.getRenameClass().setEnabled(deobfPanel.deobfClasses.getSelectedClass() != null);
 			}
 		});
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -295,11 +295,15 @@ public class Gui implements LanguageChangeListener {
 			@Override
 			public void mousePressed(MouseEvent e) {
 				if (SwingUtilities.isRightMouseButton(e)) {
+					deobfPanel.deobfClasses.setSelectionRow(deobfPanel.deobfClasses.getClosestRowForLocation(e.getX(), e.getY()));
 					int i = deobfPanel.deobfClasses.getRowForPath(deobfPanel.deobfClasses.getSelectionPath());
 					if (i != -1) {
 						deobfPanelPopupMenu.show(deobfPanel.deobfClasses, e.getX(), e.getY());
 					}
 				}
+
+				// Only enable rename class if selected path is a class
+				deobfPanelPopupMenu.getRenameClass().setEnabled(deobfPanel.deobfClasses.getSelectedClass() != null);
 			}
 		});
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/DeobfPanelPopupMenu.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/DeobfPanelPopupMenu.java
@@ -5,21 +5,39 @@ import cuchaz.enigma.gui.Gui;
 import cuchaz.enigma.utils.I18n;
 
 import javax.swing.*;
+import javax.swing.tree.TreePath;
 import java.awt.*;
 
 public class DeobfPanelPopupMenu {
 
     private final JPopupMenu ui;
-    private final JMenuItem rename;
+    private final JMenuItem renamePackage;
+    private final JMenuItem renameClass;
 
     public DeobfPanelPopupMenu(Gui gui) {
         this.ui = new JPopupMenu();
 
         ClassSelector deobfClasses = gui.getDeobfPanel().deobfClasses;
 
-        this.rename = new JMenuItem();
-        this.rename.addActionListener(a -> deobfClasses.getUI().startEditingAtPath(deobfClasses, deobfClasses.getSelectionPath()));
-        this.ui.add(this.rename);
+        this.renamePackage = new JMenuItem();
+        this.renamePackage.addActionListener(a -> {
+            TreePath path;
+
+            if (deobfClasses.getSelectedClass() != null) {
+                // Rename parent package if selected path is a class
+                path = deobfClasses.getSelectionPath().getParentPath();
+            } else {
+                // Rename selected path if it's already a package
+                path = deobfClasses.getSelectionPath();
+            }
+
+            deobfClasses.getUI().startEditingAtPath(deobfClasses, path);
+        });
+        this.ui.add(this.renamePackage);
+
+        this.renameClass = new JMenuItem();
+        this.renameClass.addActionListener(a -> deobfClasses.getUI().startEditingAtPath(deobfClasses, deobfClasses.getSelectionPath()));
+        this.ui.add(this.renameClass);
 
         this.retranslateUi();
     }
@@ -29,6 +47,11 @@ public class DeobfPanelPopupMenu {
     }
 
     public void retranslateUi() {
-        this.rename.setText(I18n.translate("popup_menu.deobf_panel.rename"));
+        this.renamePackage.setText(I18n.translate("popup_menu.deobf_panel.rename_package"));
+        this.renameClass.setText(I18n.translate("popup_menu.deobf_panel.rename_class"));
+    }
+
+    public JMenuItem getRenameClass() {
+        return this.renameClass;
     }
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/DeobfPanelPopupMenu.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/DeobfPanelPopupMenu.java
@@ -42,16 +42,15 @@ public class DeobfPanelPopupMenu {
         this.retranslateUi();
     }
 
-    public void show(Component invoker, int x, int y) {
-        this.ui.show(invoker, x, y);
+    public void show(ClassSelector deobfClasses, int x, int y) {
+        // Only enable rename class if selected path is a class
+        this.renameClass.setEnabled(deobfClasses.getSelectedClass() != null);
+
+        this.ui.show(deobfClasses, x, y);
     }
 
     public void retranslateUi() {
         this.renamePackage.setText(I18n.translate("popup_menu.deobf_panel.rename_package"));
         this.renameClass.setText(I18n.translate("popup_menu.deobf_panel.rename_class"));
-    }
-
-    public JMenuItem getRenameClass() {
-        return this.renameClass;
     }
 }

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -79,7 +79,8 @@
 	"popup_menu.editor_tab.close_others": "Close Others",
 	"popup_menu.editor_tab.close_left": "Close All to the Left",
 	"popup_menu.editor_tab.close_right": "Close All to the Right",
-	"popup_menu.deobf_panel.rename": "Rename",
+	"popup_menu.deobf_panel.rename_package": "Rename Package",
+	"popup_menu.deobf_panel.rename_class": "Rename Class",
 
 	"editor.decompiling": "Decompiling...",
 	"editor.decompile_error": "An error was encountered while decompiling.",

--- a/enigma/src/main/resources/lang/fr_fr.json
+++ b/enigma/src/main/resources/lang/fr_fr.json
@@ -79,7 +79,8 @@
 	"popup_menu.editor_tab.close_others": "Fermer les autres",
 	"popup_menu.editor_tab.close_left": "Tout fermer sur la gauche",
 	"popup_menu.editor_tab.close_right": "Tout fermer sur la droite",
-	"popup_menu.deobf_panel.rename": "Renommer",
+	"popup_menu.deobf_panel.rename_package": "Renommer le package",
+	"popup_menu.deobf_panel.rename_class": "Renommer la classe",
 
 	"editor.decompiling": "Décompilation...",
 	"editor.decompile_error": "Une erreur est survenue lors de la décompilation.",


### PR DESCRIPTION
- Right clicking now select the closest path before opening the popup menu (instead of opening it for any previously selected path)
- Replaced the rename item with a rename package and a rename class items
  - "Rename Package" rename the parent package if path is a class, or the path if it's already a package
  - "Rename Class" rename the path only if it's a class, otherwise the item is disabled