### PR TITLE
Fix inner classes' javadocs not invalidated properly

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
@@ -129,6 +129,11 @@ public final class ClassHandleProvider {
 			if (e != null) {
 				e.invalidateJavadoc();
 			}
+
+			Entry outermostEntry = handles.get(entry.getOutermostClass());
+			if (outermostEntry != null) {
+				outermostEntry.invalidateJavadoc();
+			}
 		});
 	}
 

--- a/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
@@ -130,9 +130,8 @@ public final class ClassHandleProvider {
 				e.invalidateJavadoc();
 			}
 
-			Entry outermostEntry = handles.get(entry.getOutermostClass());
-			if (outermostEntry != null) {
-				outermostEntry.invalidateJavadoc();
+			if (entry.isInnerClass()) {
+				this.invalidateJavadoc(entry.getOuterClass());
 			}
 		});
 	}


### PR DESCRIPTION
When saving javadocs on inner classes, they were not displayed on the editor panel without closing and reopening the outer class.
This PR fixes that by invalidating javadocs on the outermost parent class in addition to the class where javadocs are added.

Closes #276 