### PR TITLE
Fixes open declaration not opening declaration

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -273,7 +273,7 @@ public class GuiController implements ClientPacketHandler {
 		if (entry == null) {
 			throw new IllegalArgumentException("Entry cannot be null!");
 		}
-		openReference(new EntryReference<>(entry, entry.getName()));
+		openReference(EntryReference.declaration(entry, entry.getName()));
 	}
 
 	/**
@@ -301,7 +301,7 @@ public class GuiController implements ClientPacketHandler {
 	 * @param reference the reference
 	 */
 	private void setReference(EntryReference<Entry<?>, Entry<?>> reference) {
-		gui.openClass(reference.getLocationClassEntry()).showReference(reference);
+		gui.openClass(reference.getLocationClassEntry().getOutermostClass()).showReference(reference);
 	}
 
 	public Collection<Token> getTokensForReference(DecompiledClassSource source, EntryReference<Entry<?>, Entry<?>> reference) {

--- a/enigma/src/main/java/cuchaz/enigma/source/SourceIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/SourceIndex.java
@@ -88,6 +88,7 @@ public class SourceIndex {
             EntryReference<Entry<?>, Entry<?>> reference = new EntryReference<>(deobfEntry, token.text);
             tokenToReference.put(token, reference);
             referenceToTokens.put(reference, token);
+            referenceToTokens.put(EntryReference.declaration(deobfEntry, token.text), token);
             declarationToToken.put(deobfEntry, token);
         }
     }


### PR DESCRIPTION
The problem is that "open declaration" does not open declaration; it only goes to the topmost token in the class where the declaration is. Edited entry reference to add "declaration reference" for navigation.

Example: Look at the `setPosition` call in `Entity`'s constructor. When you navigate you will go back to the constructor because it is the first occurrence of `setPosition`.

This bug may have been overlooked because for fields and classes, their definitions usually are lucky enough to be the first references in their files.

Also make navigating to a reference open the outermost than the inner class. For example, look at the implementations of `EntityData`. Now you will not go to `PassiveEntity$PassiveData` but will just go to `PassiveEntity`.

Imo this bug is significant and affects testing of #336. I request reviews from @2xsaiko and @Gegy 