### PR TITLE
Fix the structure panel not updating if switching to an existing tab

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -489,12 +489,11 @@ public class Gui implements LanguageChangeListener {
 				}
 			});
 
-			showStructure(ed);
-
 			return ed;
 		});
 		if (editorPanel != null) {
 			openFiles.setSelectedComponent(editors.get(entry).getUi());
+			showStructure(editorPanel);
 		}
 
 		return editorPanel;


### PR DESCRIPTION
Fixes a bug where the structure panel would not update the shown class when the user switches to a previously opened tab.

The cause was that the `showStructure` call was inside a `computeIfAbsent`, so it wasn't called when the editor already existed. I moved the call to the following `if (editorPanel != null)` block instead.