### PR TITLE
Migrate to FlatLaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Enigma includes the following open-source libraries:
  - A [modified version](https://github.com/FabricMC/cfr) of [CFR](https://github.com/leibnitz27/cfr) (MIT)
  - [Guava](https://github.com/google/guava) (Apache-2.0)
  - [SyntaxPane](https://github.com/Sciss/SyntaxPane) (Apache-2.0)
- - [Darcula](https://github.com/bulenkov/Darcula) (Apache-2.0)
+ - [FlatLaf](https://github.com/JFormDesigner/FlatLaf) (Apache-2.0)
  - [jopt-simple](https://github.com/jopt-simple/jopt-simple) (MIT)
  - [ASM](https://asm.ow2.io/) (BSD-3-Clause)
 

--- a/enigma-swing/build.gradle
+++ b/enigma-swing/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation project(':enigma-server')
 
     implementation 'net.sf.jopt-simple:jopt-simple:6.0-alpha-3'
-    implementation 'com.bulenkov:darcula:1.0.0-bobbylight'
+    implementation 'com.formdev:flatlaf:1.0'
     implementation 'de.sciss:syntaxpane:1.2.0'
     implementation 'com.github.lukeu:swing-dpi:0.6'
     implementation 'org.drjekyll:fontchooser:2.4'

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/EnigmaSyntaxKit.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/EnigmaSyntaxKit.java
@@ -7,6 +7,8 @@ import de.sciss.syntaxpane.util.Configuration;
 
 import cuchaz.enigma.gui.config.UiConfig;
 
+import java.awt.Font;
+
 public class EnigmaSyntaxKit extends JavaSyntaxKit {
 
 	private static Configuration configuration = null;
@@ -53,7 +55,8 @@ public class EnigmaSyntaxKit extends JavaSyntaxKit {
 
 		configuration.put("Action.quick-find", "cuchaz.enigma.gui.QuickFindAction, menu F");
 
-        configuration.put("DefaultFont", UiConfig.encodeFont(UiConfig.getEditorFont()));
+		Font editorFont = UiConfig.shouldUseCustomFonts() ? UiConfig.getEditorFont() : UiConfig.getFallbackEditorFont();
+		configuration.put("DefaultFont", UiConfig.encodeFont(editorFont));
     }
 
     /**

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
@@ -8,16 +8,18 @@ import javax.swing.JPanel;
 import javax.swing.UIManager;
 import javax.swing.plaf.metal.MetalLookAndFeel;
 
-import com.bulenkov.darcula.DarculaLaf;
+import com.formdev.flatlaf.FlatDarculaLaf;
+import com.formdev.flatlaf.FlatLightLaf;
 
 public enum LookAndFeel {
 	DEFAULT("Default"),
 	DARCULA("Darcula"),
+	METAL("Metal"),
 	SYSTEM("System"),
 	NONE("None (JVM default)");
 
 	// the "JVM default" look and feel, get it at the beginning and store it so we can set it later
-	private static javax.swing.LookAndFeel NONE_LAF = UIManager.getLookAndFeel();
+	private static final javax.swing.LookAndFeel NONE_LAF = UIManager.getLookAndFeel();
 	private final String name;
 
 	LookAndFeel(String name) {
@@ -35,10 +37,13 @@ public enum LookAndFeel {
 					UIManager.setLookAndFeel(NONE_LAF);
 					break;
 				case DEFAULT:
+					UIManager.setLookAndFeel(new FlatLightLaf());
+					break;
+				case METAL:
 					UIManager.setLookAndFeel(new MetalLookAndFeel());
 					break;
 				case DARCULA:
-					UIManager.setLookAndFeel(new DarculaLaf());
+					UIManager.setLookAndFeel(new FlatDarculaLaf());
 					break;
 				case SYSTEM:
 					UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
@@ -11,20 +11,32 @@ import javax.swing.plaf.metal.MetalLookAndFeel;
 import com.formdev.flatlaf.FlatDarculaLaf;
 import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.FlatSystemProperties;
+import cuchaz.enigma.gui.util.ScaleUtil;
 
 public enum LookAndFeel {
-	DEFAULT,
-	DARCULA,
-	METAL,
-	SYSTEM,
-	NONE;
+	DEFAULT(false),
+	DARCULA(false),
+	METAL(true),
+	SYSTEM(true),
+	NONE(true);
 
 	// the "JVM default" look and feel, get it at the beginning and store it so we can set it later
 	private static final javax.swing.LookAndFeel NONE_LAF = UIManager.getLookAndFeel();
+	private final boolean needsScaling;
+
+	LookAndFeel(boolean needsScaling) {
+		this.needsScaling = needsScaling;
+	}
+
+	public boolean needsScaling() {
+		// FlatLaf-based LaFs do their own scaling so we don't have to do it.
+		// Running swing-dpi for FlatLaf actually breaks fonts, so we let it scale the GUI.
+		return needsScaling;
+	}
 
 	public void setGlobalLAF() {
-		// Disable FlatLaf's UI scaling, we do it on our own
-		System.setProperty(FlatSystemProperties.UI_SCALE_ENABLED, "false");
+		// Configure FlatLaf's UI scale to be our scale factor.
+		System.setProperty(FlatSystemProperties.UI_SCALE, Float.toString(ScaleUtil.getScaleFactor()));
 
 		try {
 			switch (this) {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
@@ -10,6 +10,7 @@ import javax.swing.plaf.metal.MetalLookAndFeel;
 
 import com.formdev.flatlaf.FlatDarculaLaf;
 import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.FlatSystemProperties;
 
 public enum LookAndFeel {
 	DEFAULT("Default"),
@@ -31,6 +32,9 @@ public enum LookAndFeel {
 	}
 
 	public void setGlobalLAF() {
+		// Disable FlatLaf's UI scaling, we do it on our own
+		System.setProperty(FlatSystemProperties.UI_SCALE_ENABLED, "false");
+
 		try {
 			switch (this) {
 				case NONE:

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
@@ -8,7 +8,7 @@ import javax.swing.JPanel;
 import javax.swing.UIManager;
 import javax.swing.plaf.metal.MetalLookAndFeel;
 
-import com.formdev.flatlaf.FlatDarculaLaf;
+import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.FlatSystemProperties;
 import cuchaz.enigma.gui.util.ScaleUtil;
@@ -50,7 +50,7 @@ public enum LookAndFeel {
 					UIManager.setLookAndFeel(new MetalLookAndFeel());
 					break;
 				case DARCULA:
-					UIManager.setLookAndFeel(new FlatDarculaLaf());
+					UIManager.setLookAndFeel(new FlatDarkLaf());
 					break;
 				case SYSTEM:
 					UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/LookAndFeel.java
@@ -13,23 +13,14 @@ import com.formdev.flatlaf.FlatLightLaf;
 import com.formdev.flatlaf.FlatSystemProperties;
 
 public enum LookAndFeel {
-	DEFAULT("Default"),
-	DARCULA("Darcula"),
-	METAL("Metal"),
-	SYSTEM("System"),
-	NONE("None (JVM default)");
+	DEFAULT,
+	DARCULA,
+	METAL,
+	SYSTEM,
+	NONE;
 
 	// the "JVM default" look and feel, get it at the beginning and store it so we can set it later
 	private static final javax.swing.LookAndFeel NONE_LAF = UIManager.getLookAndFeel();
-	private final String name;
-
-	LookAndFeel(String name) {
-		this.name = name;
-	}
-
-	public String getName() {
-		return name;
-	}
 
 	public void setGlobalLAF() {
 		// Disable FlatLaf's UI scaling, we do it on our own

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
@@ -220,11 +220,25 @@ public final class UiConfig {
 	}
 
 	public static Font getEditorFont() {
-		return getFont("Editor").orElseGet(() -> ScaleUtil.scaleFont(Font.decode(Font.MONOSPACED)));
+		return getFont("Editor").orElseGet(UiConfig::getFallbackEditorFont);
 	}
 
 	public static void setEditorFont(Font font) {
 		setFont("Editor", font);
+	}
+
+	/**
+	 * Gets the fallback editor font.
+	 * It is used
+	 * <ul>
+	 * <li>when there is no custom editor font chosen</li>
+	 * <li>when custom fonts are disabled</li>
+	 * </ul>
+	 *
+	 * @return the fallback editor font
+	 */
+	public static Font getFallbackEditorFont() {
+		return ScaleUtil.scaleFont(Font.decode(Font.MONOSPACED));
 	}
 
 	public static String encodeFont(Font font) {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -79,7 +79,7 @@ public class JavadocDialog {
 				}
 			}
 		});
-		this.text.setFont(UiConfig.getEditorFont());
+		this.text.setFont(UiConfig.shouldUseCustomFonts() ? UiConfig.getEditorFont() : UiConfig.getFallbackEditorFont());
 
 		// buttons panel
 		JPanel buttonsPanel = new JPanel();

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -25,6 +25,7 @@ import com.google.common.base.Strings;
 
 import cuchaz.enigma.analysis.EntryReference;
 import cuchaz.enigma.gui.GuiController;
+import cuchaz.enigma.gui.config.UiConfig;
 import cuchaz.enigma.gui.elements.ValidatableTextArea;
 import cuchaz.enigma.gui.util.GuiUtil;
 import cuchaz.enigma.gui.util.ScaleUtil;
@@ -78,6 +79,7 @@ public class JavadocDialog {
 				}
 			}
 		});
+		this.text.setFont(UiConfig.getEditorFont());
 
 		// buttons panel
 		JPanel buttonsPanel = new JPanel();

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/ScaleUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/ScaleUtil.java
@@ -95,7 +95,11 @@ public class ScaleUtil {
 
 	public static void applyScaling() {
 		float scale = getScaleFactor();
-		UiDefaultsScaler.updateAndApplyGlobalScaling((int) (100 * scale), true);
+
+		if (UiConfig.getLookAndFeel().needsScaling()) {
+			UiDefaultsScaler.updateAndApplyGlobalScaling((int) (100 * scale), true);
+		}
+
 		try {
 			Field defaultFontField = DefaultSyntaxKit.class.getDeclaredField("DEFAULT_FONT");
 			defaultFontField.setAccessible(true);

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -36,6 +36,7 @@
 	"menu.view.themes": "Themes",
 	"menu.view.themes.default": "Default",
 	"menu.view.themes.darcula": "Darcula",
+	"menu.view.themes.metal": "Metal",
 	"menu.view.themes.system": "System",
 	"menu.view.themes.none": "None (JVM Default)",
 	"menu.view.languages": "Languages",


### PR DESCRIPTION
Fixes #355.

- Replaces the Darcula look and feel with [FlatLaf](https://github.com/JFormDesigner/FlatLaf)'s dark colour scheme.
  - FlatLaf does not have the same rendering bugs with CJK characters (at least on Windows 10).
  - FlatLaf is also under Apache 2.0, so we can use it as a drop-in replacement. It also looks almost identical to Darcula with the dark theme as they have the same colours and overall style.
- Replaces Metal with FlatLaf Light as the default look and feel. Metal is provided as a new, separate theme option.
  - FlatLaf Light looks a lot better than Metal (especially as a default theme for a modern application), so I decided to use it as the default. Metal can still be used with the other options.
- The javadoc editor dialog's text box now uses the editor font for consistency.
- Fixed the editor using custom fonts even if they're disabled.