### PR TITLE
Icons everywhere

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -40,6 +40,10 @@ import cuchaz.enigma.gui.dialog.SearchDialog;
 import cuchaz.enigma.gui.elements.*;
 import cuchaz.enigma.gui.events.EditorActionListener;
 import cuchaz.enigma.gui.panels.*;
+import cuchaz.enigma.gui.renderer.CallsTreeCellRenderer;
+import cuchaz.enigma.gui.renderer.ImplementationsTreeCellRenderer;
+import cuchaz.enigma.gui.renderer.InheritanceTreeCellRenderer;
+import cuchaz.enigma.gui.renderer.MessageListCellRenderer;
 import cuchaz.enigma.gui.util.History;
 import cuchaz.enigma.gui.util.LanguageChangeListener;
 import cuchaz.enigma.gui.util.LanguageUtil;
@@ -167,6 +171,7 @@ public class Gui implements LanguageChangeListener {
 		// init inheritance panel
 		inheritanceTree = new JTree();
 		inheritanceTree.setModel(null);
+		inheritanceTree.setCellRenderer(new InheritanceTreeCellRenderer(this));
 		inheritanceTree.setShowsRootHandles(true);
 		inheritanceTree.addMouseListener(new MouseAdapter() {
 			@Override
@@ -191,8 +196,6 @@ public class Gui implements LanguageChangeListener {
 				}
 			}
 		});
-		TreeCellRenderer cellRenderer = inheritanceTree.getCellRenderer();
-		inheritanceTree.setCellRenderer(new MethodTreeCellRenderer(cellRenderer));
 
 		JPanel inheritancePanel = new JPanel();
 		inheritancePanel.setLayout(new BorderLayout());
@@ -201,6 +204,7 @@ public class Gui implements LanguageChangeListener {
 		// init implementations panel
 		implementationsTree = new JTree();
 		implementationsTree.setModel(null);
+		implementationsTree.setCellRenderer(new ImplementationsTreeCellRenderer(this));
 		implementationsTree.setShowsRootHandles(true);
 		implementationsTree.addMouseListener(new MouseAdapter() {
 			@Override
@@ -230,6 +234,7 @@ public class Gui implements LanguageChangeListener {
 		// init call panel
 		callsTree = new JTree();
 		callsTree.setModel(null);
+		callsTree.setCellRenderer(new CallsTreeCellRenderer(this));
 		callsTree.setShowsRootHandles(true);
 		callsTree.addMouseListener(new MouseAdapter() {
 			@SuppressWarnings("unchecked")
@@ -947,6 +952,7 @@ public class Gui implements LanguageChangeListener {
 		this.deobfPanelPopupMenu.retranslateUi();
 		this.infoPanel.retranslateUi();
 		this.structurePanel.retranslateUi();
+		this.editorTabPopupMenu.retranslateUi();
 		this.editors.values().forEach(EditorPanel::retranslateUi);
 	}
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/EditorTabPopupMenu.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/EditorTabPopupMenu.java
@@ -28,26 +28,28 @@ public class EditorTabPopupMenu {
 
 		this.ui = new JPopupMenu();
 
-		this.close = new JMenuItem(I18n.translate("popup_menu.editor_tab.close"));
+		this.close = new JMenuItem();
 		this.close.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_4, KeyEvent.CTRL_DOWN_MASK));
 		this.close.addActionListener(a -> gui.closeEditor(editor));
 		this.ui.add(this.close);
 
-		this.closeAll = new JMenuItem(I18n.translate("popup_menu.editor_tab.close_all"));
+		this.closeAll = new JMenuItem();
 		this.closeAll.addActionListener(a -> gui.closeAllEditorTabs());
 		this.ui.add(this.closeAll);
 
-		this.closeOthers = new JMenuItem(I18n.translate("popup_menu.editor_tab.close_others"));
+		this.closeOthers = new JMenuItem();
 		this.closeOthers.addActionListener(a -> gui.closeTabsExcept(editor));
 		this.ui.add(this.closeOthers);
 
-		this.closeLeft = new JMenuItem(I18n.translate("popup_menu.editor_tab.close_left"));
+		this.closeLeft = new JMenuItem();
 		this.closeLeft.addActionListener(a -> gui.closeTabsLeftOf(editor));
 		this.ui.add(this.closeLeft);
 
-		this.closeRight = new JMenuItem(I18n.translate("popup_menu.editor_tab.close_right"));
+		this.closeRight = new JMenuItem();
 		this.closeRight.addActionListener(a -> gui.closeTabsRightOf(editor));
 		this.ui.add(this.closeRight);
+
+		this.retranslateUi();
 	}
 
 	public void show(Component invoker, int x, int y, EditorPanel editorPanel) {
@@ -55,4 +57,11 @@ public class EditorTabPopupMenu {
 		ui.show(invoker, x, y);
 	}
 
+	public void retranslateUi() {
+		this.close.setText(I18n.translate("popup_menu.editor_tab.close"));
+		this.closeAll.setText(I18n.translate("popup_menu.editor_tab.close_all"));
+		this.closeOthers.setText(I18n.translate("popup_menu.editor_tab.close_others"));
+		this.closeLeft.setText(I18n.translate("popup_menu.editor_tab.close_left"));
+		this.closeRight.setText(I18n.translate("popup_menu.editor_tab.close_right"));
+	}
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/StructurePanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/StructurePanel.java
@@ -84,13 +84,13 @@ public class StructurePanel extends JPanel {
 
         @Override
         public Component getTreeCellRendererComponent(JTree tree, Object value, boolean selected, boolean expanded, boolean leaf, int row, boolean hasFocus) {
-            JComponent c = (JComponent) super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
-            ParentedEntry entry = ((StructureTreeNode) value).getEntry();
+            Component c = super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
+            ParentedEntry<?> entry = ((StructureTreeNode) value).getEntry();
 
             if (entry instanceof ClassEntry) {
                 this.setIcon(GuiUtil.getClassIcon(gui, (ClassEntry) entry));
             } else if (entry instanceof MethodEntry) {
-                this.setIcon(((MethodEntry) entry).isConstructor() ? GuiUtil.CONSTRUCTOR_ICON : GuiUtil.METHOD_ICON);
+                this.setIcon(GuiUtil.getMethodIcon((MethodEntry) entry));
             } else if (entry instanceof FieldEntry) {
                 this.setIcon(GuiUtil.FIELD_ICON);
             }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/CallsTreeCellRenderer.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/CallsTreeCellRenderer.java
@@ -1,0 +1,45 @@
+package cuchaz.enigma.gui.renderer;
+
+import cuchaz.enigma.analysis.*;
+import cuchaz.enigma.gui.Gui;
+import cuchaz.enigma.gui.config.UiConfig;
+import cuchaz.enigma.gui.util.GuiUtil;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import java.awt.*;
+
+public class CallsTreeCellRenderer extends DefaultTreeCellRenderer {
+    private final Gui gui;
+
+    public CallsTreeCellRenderer(Gui gui) {
+        this.gui = gui;
+    }
+
+    @Override
+    public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {
+        Component c = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+        EntryReference<?, ?> reference = ((ReferenceTreeNode<?, ?>) value).getReference();
+
+        this.setForeground(UiConfig.getTextColor());
+
+        // if the node represents the method calling the entry
+        if (reference != null) {
+            if (reference.context instanceof MethodEntry) {
+                this.setIcon(GuiUtil.getMethodIcon((MethodEntry) reference.context));
+            }
+        // if the node represents the called entry
+        } else {
+            if (value instanceof ClassReferenceTreeNode) {
+                this.setIcon(GuiUtil.getClassIcon(this.gui, ((ClassReferenceTreeNode) value).getEntry()));
+            } else if (value instanceof MethodReferenceTreeNode) {
+                this.setIcon(GuiUtil.getMethodIcon(((MethodReferenceTreeNode) value).getEntry()));
+            } else if (value instanceof FieldReferenceTreeNode) {
+                this.setIcon(GuiUtil.FIELD_ICON);
+            }
+        }
+
+        return c;
+    }
+}

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/ImplementationsTreeCellRenderer.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/ImplementationsTreeCellRenderer.java
@@ -1,0 +1,34 @@
+package cuchaz.enigma.gui.renderer;
+
+import cuchaz.enigma.analysis.ClassImplementationsTreeNode;
+import cuchaz.enigma.analysis.MethodImplementationsTreeNode;
+import cuchaz.enigma.gui.Gui;
+import cuchaz.enigma.gui.config.UiConfig;
+import cuchaz.enigma.gui.util.GuiUtil;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import java.awt.*;
+
+public class ImplementationsTreeCellRenderer extends DefaultTreeCellRenderer {
+    private final Gui gui;
+
+    public ImplementationsTreeCellRenderer(Gui gui) {
+        this.gui = gui;
+    }
+
+    @Override
+    public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {
+        Component c = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus);
+
+        this.setForeground(UiConfig.getTextColor());
+
+        if (value instanceof ClassImplementationsTreeNode) {
+            this.setIcon(GuiUtil.getClassIcon(this.gui, ((ClassImplementationsTreeNode) value).getClassEntry()));
+        } else if (value instanceof MethodImplementationsTreeNode) {
+            this.setIcon(GuiUtil.getMethodIcon(((MethodImplementationsTreeNode) value).getMethodEntry()));
+        }
+
+        return c;
+    }
+}

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/InheritanceTreeCellRenderer.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/InheritanceTreeCellRenderer.java
@@ -9,35 +9,45 @@
  * Jeff Martin - initial API and implementation
  ******************************************************************************/
 
-package cuchaz.enigma.gui;
+package cuchaz.enigma.gui.renderer;
 
 import java.awt.Component;
 import java.awt.Font;
 
 import javax.swing.JTree;
-import javax.swing.tree.TreeCellRenderer;
+import javax.swing.tree.DefaultTreeCellRenderer;
 
+import cuchaz.enigma.analysis.ClassInheritanceTreeNode;
 import cuchaz.enigma.analysis.MethodInheritanceTreeNode;
+import cuchaz.enigma.gui.Gui;
 import cuchaz.enigma.gui.config.UiConfig;
+import cuchaz.enigma.gui.util.GuiUtil;
 
-class MethodTreeCellRenderer implements TreeCellRenderer {
+public class InheritanceTreeCellRenderer extends DefaultTreeCellRenderer {
+	private final Gui gui;
 
-	private final TreeCellRenderer parent;
-
-	MethodTreeCellRenderer(TreeCellRenderer parent) {
-		this.parent = parent;
+	public InheritanceTreeCellRenderer(Gui gui) {
+		this.gui = gui;
 	}
 
 	@Override
 	public Component getTreeCellRendererComponent(JTree tree, Object value, boolean selected, boolean expanded, boolean leaf, int row, boolean hasFocus) {
-		Component ret = parent.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
+		Component ret = super.getTreeCellRendererComponent(tree, value, selected, expanded, leaf, row, hasFocus);
+
 		if (!(value instanceof MethodInheritanceTreeNode) || ((MethodInheritanceTreeNode) value).isImplemented()) {
 			ret.setForeground(UiConfig.getTextColor());
 			ret.setFont(ret.getFont().deriveFont(Font.PLAIN));
+			if (value instanceof ClassInheritanceTreeNode) {
+				this.setIcon(GuiUtil.getClassIcon(this.gui, ((ClassInheritanceTreeNode) value).getClassEntry()));
+			} else if (value instanceof MethodInheritanceTreeNode) {
+				this.setIcon(GuiUtil.getMethodIcon(((MethodInheritanceTreeNode) value).getMethodEntry()));
+			}
 		} else {
 			ret.setForeground(UiConfig.getNumberColor());
 			ret.setFont(ret.getFont().deriveFont(Font.ITALIC));
+			this.setIcon(GuiUtil.CLASS_ICON);
 		}
+
 		return ret;
 	}
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/MessageListCellRenderer.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/MessageListCellRenderer.java
@@ -1,4 +1,4 @@
-package cuchaz.enigma.gui;
+package cuchaz.enigma.gui.renderer;
 
 import java.awt.Component;
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/GuiUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/GuiUtil.java
@@ -3,6 +3,7 @@ package cuchaz.enigma.gui.util;
 import cuchaz.enigma.gui.Gui;
 import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
 import cuchaz.enigma.utils.Os;
 
 import javax.imageio.ImageIO;
@@ -105,5 +106,12 @@ public class GuiUtil {
         }
 
         return CLASS_ICON;
+    }
+
+    public static Icon getMethodIcon(MethodEntry entry) {
+        if (entry.isConstructor()) {
+            return CONSTRUCTOR_ICON;
+        }
+        return METHOD_ICON;
     }
 }

--- a/enigma/src/main/java/cuchaz/enigma/analysis/ClassInheritanceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/ClassInheritanceTreeNode.java
@@ -44,6 +44,13 @@ public class ClassInheritanceTreeNode extends DefaultMutableTreeNode {
 		return null;
 	}
 
+	/**
+	 * Returns the class entry represented by this tree node.
+	 */
+	public ClassEntry getClassEntry() {
+		return this.obfClassEntry;
+	}
+
 	public String getObfClassName() {
 		return this.obfClassEntry.getFullName();
 	}

--- a/enigma/src/main/java/cuchaz/enigma/analysis/MethodInheritanceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/MethodInheritanceTreeNode.java
@@ -48,6 +48,9 @@ public class MethodInheritanceTreeNode extends DefaultMutableTreeNode {
 		return null;
 	}
 
+	/**
+	 * Returns the method entry represented by this tree node.
+	 */
 	public MethodEntry getMethodEntry() {
 		return this.entry;
 	}

--- a/enigma/src/main/java/cuchaz/enigma/analysis/ReferenceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/ReferenceTreeNode.java
@@ -14,6 +14,9 @@ package cuchaz.enigma.analysis;
 import cuchaz.enigma.translation.representation.entry.Entry;
 
 public interface ReferenceTreeNode<E extends Entry<?>, C extends Entry<?>> {
+	/**
+	 * Returns the entry represented by this tree node.
+	 */
 	E getEntry();
 
 	EntryReference<E, C> getReference();

--- a/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
@@ -26,7 +26,7 @@ public class StructureTreeNode extends DefaultMutableTreeNode {
     }
 
     /**
-     * Returns the parented entry corresponding to this tree node.
+     * Returns the parented entry represented by this tree node.
      */
     public ParentedEntry getEntry() {
         return this.entry;


### PR DESCRIPTION
This PR makes the inheritance, implementations and calls trees use icons for classes/methods/fields references.
Also, fixes the editor tab popup menu not being retranslated when changing the language.

EDIT: fixes #357 (didn't see the issue before)