### PR TITLE
Record support

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
@@ -258,7 +258,15 @@ public final class UiConfig {
 		OptionalInt x = section.getInt(String.format("X %s", screenSize.width));
 		OptionalInt y = section.getInt(String.format("Y %s", screenSize.height));
 		if (x.isPresent() && y.isPresent()) {
-			return new Point(x.getAsInt(), y.getAsInt());
+			int ix = x.getAsInt();
+			int iy = y.getAsInt();
+
+			// Ensure that the position is on the screen.
+			if (ix < 0 || iy < 0 || ix > screenSize.width || iy > screenSize.height) {
+				return fallback;
+			}
+
+			return new Point(ix, iy);
 		} else {
 			return fallback;
 		}

--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
@@ -99,4 +99,13 @@ public class TranslationClassVisitor extends ClassVisitor {
 		AnnotationVisitor av = super.visitTypeAnnotation(typeRef, typePath, translatedDesc.toString(), visible);
 		return new TranslationAnnotationVisitor(translator, translatedDesc.getTypeEntry(), api, av);
 	}
+
+	@Override
+	public RecordComponentVisitor visitRecordComponent(String name, String desc, String signature) {
+		// Record component names are remapped via the field mapping.
+		FieldDefEntry entry = FieldDefEntry.parse(obfClassEntry, 0, name, desc, signature);
+		FieldDefEntry translatedEntry = translator.translate(entry);
+		RecordComponentVisitor fv = super.visitRecordComponent(translatedEntry.getName(), translatedEntry.getDesc().toString(), translatedEntry.getSignature().toString());
+		return new TranslationRecordComponentVisitor(translator, api, fv);
+	}
 }

--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationRecordComponentVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationRecordComponentVisitor.java
@@ -1,0 +1,30 @@
+package cuchaz.enigma.bytecode.translators;
+
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.representation.TypeDescriptor;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.RecordComponentVisitor;
+import org.objectweb.asm.TypePath;
+
+public class TranslationRecordComponentVisitor extends RecordComponentVisitor {
+	private final Translator translator;
+
+	public TranslationRecordComponentVisitor(Translator translator, int api, RecordComponentVisitor rcv) {
+		super(api, rcv);
+		this.translator = translator;
+	}
+
+	@Override
+	public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+		TypeDescriptor typeDesc = translator.translate(new TypeDescriptor(desc));
+		AnnotationVisitor av = super.visitAnnotation(typeDesc.toString(), visible);
+		return new TranslationAnnotationVisitor(translator, typeDesc.getTypeEntry(), api, av);
+	}
+
+	@Override
+	public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String desc, boolean visible) {
+		TypeDescriptor typeDesc = translator.translate(new TypeDescriptor(desc));
+		AnnotationVisitor av = super.visitAnnotation(typeDesc.toString(), visible);
+		return new TranslationAnnotationVisitor(translator, typeDesc.getTypeEntry(), api, av);
+	}
+}

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/AccessFlags.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/AccessFlags.java
@@ -39,6 +39,10 @@ public class AccessFlags {
 		return (flags & Opcodes.ACC_ENUM) != 0;
 	}
 
+	public boolean isRecord() {
+		return (flags & Opcodes.ACC_RECORD) != 0;
+	}
+
 	public boolean isBridge() {
 		return (flags & Opcodes.ACC_BRIDGE) != 0;
 	}

--- a/enigma/src/main/java/cuchaz/enigma/utils/validation/Message.java
+++ b/enigma/src/main/java/cuchaz/enigma/utils/validation/Message.java
@@ -15,6 +15,7 @@ public class Message {
 	public static final Message ILLEGAL_IDENTIFIER = create(Type.ERROR, "illegal_identifier");
 	public static final Message RESERVED_IDENTIFIER = create(Type.ERROR, "reserved_identifier");
 	public static final Message ILLEGAL_DOC_COMMENT_END = create(Type.ERROR, "illegal_doc_comment_end");
+	public static final Message UNKNOWN_RECORD_GETTER = create(Type.ERROR, "unknown_record_getter");
 
 	public static final Message STYLE_VIOLATION = create(Type.WARNING, "style_violation");
 

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -191,6 +191,7 @@
 	"validation.message.illegal_identifier.long": "Invalid character '%2$s' at position %3$d.",
 	"validation.message.illegal_doc_comment_end": "Javadoc comment cannot contain the character sequence '*/'.",
 	"validation.message.reserved_identifier": "'%s' is a reserved identifier.",
+	"validation.message.unknown_record_getter": "Could not find a matching record component getter for %s",
 
 	"crash.title": "%s - Crash Report",
 	"crash.summary": "%s has crashed! =(",


### PR DESCRIPTION
- Full record support include javadoc support
- The generated method getter will also get a mapping of the same name to the field.
- Also fixes a bug where engima would open off the screen.

### Known issues / Unknowns

- This assumes that the fields, methods and components will all have the same name when obfuscated, im unsure if this is always the case. If not some logic will be needed to tie them back togeather.
- When exporting a jar it is currenly failing to remap one of the records' bsmArgs in the generated `toString` method.

I'm more than a little rusty on Engima so please don't hesistate to point out any issues 👍 