### PR TITLE
Less strict JRE check

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -174,7 +174,7 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 
 	public boolean isJre() {
 		String packageName = getPackageName();
-		return packageName != null && (packageName.startsWith("java") || packageName.startsWith("javax"));
+		return packageName != null && (packageName.startsWith("java/") || packageName.startsWith("javax/"));
 	}
 
 	public static String getPackageName(String name) {


### PR DESCRIPTION
Resolves #353 

The issue here lies in that this changes the behaviour of the code by quite a bit, so alternatively the irrelevant javax check could be dropped, which would optimize the code only slightly