### PR TITLE
Bump cfr and gradle wrapper

### DIFF
--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'org.ow2.asm:asm-util:9.1'
 
     implementation 'net.fabricmc:procyon-fabric-compilertools:0.5.35.13'
-    implementation 'net.fabricmc:cfr:0.0.2'
+    implementation 'net.fabricmc:cfr:0.0.3'
 
     proGuard 'com.guardsquare:proguard-base:7.1.0-beta1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
fabric cfr 0.03 was released a while ago but not used. It fixes a few annoying problems with the current fabric cfr.

@sfPlayer1 Mind check this and publish a new enigma build and bump enigma in yarn? Now seems procyon doesn't work quite well with 16 for me, cfr may be a viable solution.