### PR TITLE
Work around SourceIndexMethodVisitor tripping over missing MEMBER_REFERENCE data for invokedynamic, print decompilation exceptions

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
@@ -300,7 +300,11 @@ public final class ClassHandleProvider {
 				Entry.this.waitingSources.forEach(s -> s.complete(source));
 				Entry.this.waitingSources.clear();
 				withLock(lock.readLock(), () -> new ArrayList<>(handles)).forEach(h -> h.onMappedSourceChanged(source));
-			}, p.pool);
+			}, p.pool)
+			.exceptionally(exc -> {
+				exc.printStackTrace();
+				return null;
+			});
 		}
 
 		public void closeHandle(ClassHandleImpl classHandle) {

--- a/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexMethodVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexMethodVisitor.java
@@ -41,24 +41,26 @@ public class SourceIndexMethodVisitor extends SourceIndexVisitor {
 	public Void visitInvocationExpression(InvocationExpression node, SourceIndex index) {
 		MemberReference ref = node.getUserData(Keys.MEMBER_REFERENCE);
 
-		// get the behavior entry
-		ClassEntry classEntry = new ClassEntry(ref.getDeclaringType().getInternalName());
-		MethodEntry methodEntry = null;
-		if (ref instanceof MethodReference) {
-			methodEntry = new MethodEntry(classEntry, ref.getName(), new MethodDescriptor(ref.getErasedSignature()));
-		}
-		if (methodEntry != null) {
-			// get the node for the token
-			AstNode tokenNode = null;
-			if (node.getTarget() instanceof MemberReferenceExpression) {
-				tokenNode = ((MemberReferenceExpression) node.getTarget()).getMemberNameToken();
-			} else if (node.getTarget() instanceof SuperReferenceExpression) {
-				tokenNode = node.getTarget();
-			} else if (node.getTarget() instanceof ThisReferenceExpression) {
-				tokenNode = node.getTarget();
+		if (ref != null) {
+			// get the behavior entry
+			ClassEntry classEntry = new ClassEntry(ref.getDeclaringType().getInternalName());
+			MethodEntry methodEntry = null;
+			if (ref instanceof MethodReference) {
+				methodEntry = new MethodEntry(classEntry, ref.getName(), new MethodDescriptor(ref.getErasedSignature()));
 			}
-			if (tokenNode != null) {
-				index.addReference(TokenFactory.createToken(index, tokenNode), methodEntry, this.methodEntry);
+			if (methodEntry != null) {
+				// get the node for the token
+				AstNode tokenNode = null;
+				if (node.getTarget() instanceof MemberReferenceExpression) {
+					tokenNode = ((MemberReferenceExpression) node.getTarget()).getMemberNameToken();
+				} else if (node.getTarget() instanceof SuperReferenceExpression) {
+					tokenNode = node.getTarget();
+				} else if (node.getTarget() instanceof ThisReferenceExpression) {
+					tokenNode = node.getTarget();
+				}
+				if (tokenNode != null) {
+					index.addReference(TokenFactory.createToken(index, tokenNode), methodEntry, this.methodEntry);
+				}
 			}
 		}
 


### PR DESCRIPTION
The problem caused Enigma to get stuck in the "decompiling" state forever without any indication of what's wrong, with the workaround everything appears to work as expected, other similar issues will print an exception to stdout.

Offending class: 1.17-rc2 net.minecraft.entity.ai.brain.BlockPosLookTarget with Procyon

node with missing ref is `invokedynamic(makeConcatWithConstants:(Lnet/minecraft/class_2338;Lnet/minecraft/class_243;)Ljava/lang/String;, this.field_18340, this.field_18341)`