### PR TITLE
Use JFileChooser for all open/save operations

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -13,7 +13,6 @@ package cuchaz.enigma.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Container;
-import java.awt.FileDialog;
 import java.awt.Point;
 import java.awt.event.*;
 import java.nio.file.Path;
@@ -75,11 +74,11 @@ public class Gui implements LanguageChangeListener {
 	private ConnectionState connectionState;
 	private boolean isJarOpen;
 
-	public FileDialog jarFileChooser;
-	public FileDialog tinyMappingsFileChooser;
+	public JFileChooser jarFileChooser;
+	public JFileChooser tinyMappingsFileChooser;
 	public JFileChooser enigmaMappingsFileChooser;
 	public JFileChooser exportSourceFileChooser;
-	public FileDialog exportJarFileChooser;
+	public JFileChooser exportJarFileChooser;
 	public SearchDialog searchDialog;
 	private GuiController controller;
 	private JFrame frame;
@@ -135,9 +134,13 @@ public class Gui implements LanguageChangeListener {
 		this.controller = new GuiController(this, profile);
 
 		// init file choosers
-		this.jarFileChooser = new FileDialog(getFrame(), I18n.translate("menu.file.jar.open"), FileDialog.LOAD);
+		this.jarFileChooser = new JFileChooser();
+		this.jarFileChooser.setDialogTitle(I18n.translate("menu.file.jar.open"));
+		this.jarFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
 
-		this.tinyMappingsFileChooser = new FileDialog(getFrame(), "Open tiny Mappings", FileDialog.LOAD);
+		this.tinyMappingsFileChooser = new JFileChooser();
+		this.tinyMappingsFileChooser.setDialogTitle("Open tiny Mappings");
+		this.tinyMappingsFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
 
 		this.enigmaMappingsFileChooser = new JFileChooser();
 		this.enigmaMappingsFileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
@@ -147,7 +150,9 @@ public class Gui implements LanguageChangeListener {
 		this.exportSourceFileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 		this.exportSourceFileChooser.setAcceptAllFileFilterUsed(false);
 
-		this.exportJarFileChooser = new FileDialog(getFrame(), I18n.translate("menu.file.export.jar"), FileDialog.SAVE);
+		this.exportJarFileChooser = new JFileChooser();
+		this.exportJarFileChooser.setDialogTitle(I18n.translate("menu.file.export.jar"));
+		this.exportJarFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
 
 		this.obfPanel = new ObfPanel(this);
 		this.deobfPanel = new DeobfPanel(this);
@@ -931,8 +936,8 @@ public class Gui implements LanguageChangeListener {
 
 	@Override
 	public void retranslateUi() {
-		this.jarFileChooser.setTitle(I18n.translate("menu.file.jar.open"));
-		this.exportJarFileChooser.setTitle(I18n.translate("menu.file.export.jar"));
+		this.jarFileChooser.setDialogTitle(I18n.translate("menu.file.jar.open"));
+		this.exportJarFileChooser.setDialogTitle(I18n.translate("menu.file.export.jar"));
 		this.tabs.setTitleAt(0, I18n.translate("info_panel.tree.structure"));
 		this.tabs.setTitleAt(1, I18n.translate("info_panel.tree.inheritance"));
 		this.tabs.setTitleAt(2, I18n.translate("info_panel.tree.implementations"));

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
@@ -1,13 +1,11 @@
 package cuchaz.enigma.gui.elements;
 
-import java.awt.FileDialog;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
@@ -217,18 +215,24 @@ public class MenuBar {
 	}
 
 	private void onOpenJarClicked() {
-		FileDialog d = this.gui.jarFileChooser;
-		d.setDirectory(UiConfig.getLastSelectedDir());
+		JFileChooser d = this.gui.jarFileChooser;
+		d.setCurrentDirectory(new File(UiConfig.getLastSelectedDir()));
 		d.setVisible(true);
-		String file = d.getFile();
+		int result = d.showOpenDialog(gui.getFrame());
+
+		if (result != JFileChooser.APPROVE_OPTION) {
+			return;
+		}
+
+		File file = d.getSelectedFile();
 		// checks if the file name is not empty
 		if (file != null) {
-			Path path = Paths.get(d.getDirectory()).resolve(file);
+			Path path = file.toPath();
 			// checks if the file name corresponds to an existing file
 			if (Files.exists(path)) {
 				this.gui.getController().openJar(path);
 			}
-			UiConfig.setLastSelectedDir(d.getDirectory());
+			UiConfig.setLastSelectedDir(d.getCurrentDirectory().getAbsolutePath());
 		}
 	}
 
@@ -272,12 +276,18 @@ public class MenuBar {
 	}
 
 	private void onExportJarClicked() {
-		this.gui.exportJarFileChooser.setDirectory(UiConfig.getLastSelectedDir());
+		this.gui.exportJarFileChooser.setCurrentDirectory(new File(UiConfig.getLastSelectedDir()));
 		this.gui.exportJarFileChooser.setVisible(true);
-		if (this.gui.exportJarFileChooser.getFile() != null) {
-			Path path = Paths.get(this.gui.exportJarFileChooser.getDirectory(), this.gui.exportJarFileChooser.getFile());
+		int result = this.gui.exportJarFileChooser.showSaveDialog(gui.getFrame());
+
+		if (result != JFileChooser.APPROVE_OPTION) {
+			return;
+		}
+
+		if (this.gui.exportJarFileChooser.getSelectedFile() != null) {
+			Path path = this.gui.exportJarFileChooser.getSelectedFile().toPath();
 			this.gui.getController().exportJar(path);
-			UiConfig.setLastSelectedDir(this.gui.exportJarFileChooser.getDirectory());
+			UiConfig.setLastSelectedDir(this.gui.exportJarFileChooser.getCurrentDirectory().getAbsolutePath());
 		}
 	}
 


### PR DESCRIPTION
A number of users have reported crashes with awt's FileDialog when using Java 16. Apparenly Java 17 contains a fix for this. This is a quick PR to use JFileChooser everywhere, its not native but works.

An alternative would be use LWJGL's native bindings to https://github.com/mlabbe/nativefiledialog but that seems over the top when this is the quick and simple solution.