### PR TITLE
Add --single-class-tree argument that puts all classes into deobf panel & hides obf panel

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -74,6 +74,7 @@ public class Gui implements LanguageChangeListener {
 	private ConnectionState connectionState;
 	private boolean isJarOpen;
 	private final Set<EditableType> editableTypes;
+	public final boolean singleClassTree;
 
 	public JFileChooser jarFileChooser;
 	public JFileChooser tinyMappingsFileChooser;
@@ -113,8 +114,9 @@ public class Gui implements LanguageChangeListener {
 	private final JTabbedPane openFiles;
 	private final HashBiMap<ClassEntry, EditorPanel> editors = HashBiMap.create();
 
-	public Gui(EnigmaProfile profile, Set<EditableType> editableTypes) {
+	public Gui(EnigmaProfile profile, Set<EditableType> editableTypes, boolean singleClassTree) {
 		this.editableTypes = editableTypes;
+		this.singleClassTree = singleClassTree;
 
 		// init frame
 		this.frame = new JFrame(Enigma.NAME);
@@ -433,7 +435,7 @@ public class Gui implements LanguageChangeListener {
 		// update gui
 		this.frame.setTitle(Enigma.NAME + " - " + jarName);
 		this.classesPanel.removeAll();
-		this.classesPanel.add(splitClasses);
+		this.classesPanel.add(singleClassTree ? deobfPanel : splitClasses);
 		closeAllEditorTabs();
 
 		// update menu

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -74,7 +74,7 @@ public class Gui implements LanguageChangeListener {
 	private ConnectionState connectionState;
 	private boolean isJarOpen;
 	private final Set<EditableType> editableTypes;
-	public final boolean singleClassTree;
+	private boolean singleClassTree;
 
 	public JFileChooser jarFileChooser;
 	public JFileChooser tinyMappingsFileChooser;
@@ -114,9 +114,8 @@ public class Gui implements LanguageChangeListener {
 	private final JTabbedPane openFiles;
 	private final HashBiMap<ClassEntry, EditorPanel> editors = HashBiMap.create();
 
-	public Gui(EnigmaProfile profile, Set<EditableType> editableTypes, boolean singleClassTree) {
+	public Gui(EnigmaProfile profile, Set<EditableType> editableTypes) {
 		this.editableTypes = editableTypes;
-		this.singleClassTree = singleClassTree;
 
 		// init frame
 		this.frame = new JFrame(Enigma.NAME);
@@ -425,7 +424,19 @@ public class Gui implements LanguageChangeListener {
 	public GuiController getController() {
 		return this.controller;
 	}
-
+	
+	public void setSingleClassTree(boolean singleClassTree) {
+		this.singleClassTree = singleClassTree;
+		this.classesPanel.removeAll();
+		this.classesPanel.add(isSingleClassTree() ? deobfPanel : splitClasses);
+		getController().refreshClasses();
+		retranslateUi();
+	}
+	
+	public boolean isSingleClassTree() {
+		return singleClassTree;
+	}
+	
 	public void onStartOpenJar() {
 		this.classesPanel.removeAll();
 		redraw();
@@ -435,7 +446,7 @@ public class Gui implements LanguageChangeListener {
 		// update gui
 		this.frame.setTitle(Enigma.NAME + " - " + jarName);
 		this.classesPanel.removeAll();
-		this.classesPanel.add(singleClassTree ? deobfPanel : splitClasses);
+		this.classesPanel.add(isSingleClassTree() ? deobfPanel : splitClasses);
 		closeAllEditorTabs();
 
 		// update menu
@@ -826,7 +837,7 @@ public class Gui implements LanguageChangeListener {
 					.filter(e -> e instanceof ClassEntry)
 					.map(e -> (ClassEntry) e)
 					.filter(e -> mapper.deobfuscate(e).equals(deobf))
-					.findAny().get();
+					.findAny().orElse(deobf);
 
 			this.controller.rename(vc, new EntryReference<>(obf, obf.getFullName()), ((ClassEntry) data).getFullName(), false);
 			if (!vc.canProceed()) return;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -827,8 +827,6 @@ public class Gui implements LanguageChangeListener {
 		} else if (data instanceof ClassEntry) {
 			// class rename
 
-			// assume this is deobf since the obf tree doesn't allow renaming in
-			// the first place
 			// TODO optimize reverse class lookup, although it looks like it's
 			//      fast enough for now
 			EntryRemapper mapper = this.controller.project.getMapper();

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -364,6 +364,11 @@ public class GuiController implements ClientPacketHandler {
 				.filter(entry -> !entry.isInnerClass());
 
 		visibleClasses.forEach(entry -> {
+			if (gui.singleClassTree) {
+				deobfClasses.add(entry);
+				return;
+			}
+
 			ClassEntry deobfEntry = mapper.deobfuscate(entry);
 
 			List<ObfuscationTestService> obfService = enigma.getServices().get(ObfuscationTestService.TYPE);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -348,7 +348,9 @@ public class GuiController implements ClientPacketHandler {
 		openReference(reference);
 	}
 
-	private void refreshClasses() {
+	public void refreshClasses() {
+		if (project == null) return;
+		
 		List<ClassEntry> obfClasses = Lists.newArrayList();
 		List<ClassEntry> deobfClasses = Lists.newArrayList();
 		this.addSeparatedClasses(obfClasses, deobfClasses);
@@ -364,7 +366,7 @@ public class GuiController implements ClientPacketHandler {
 				.filter(entry -> !entry.isInnerClass());
 
 		visibleClasses.forEach(entry -> {
-			if (gui.singleClassTree) {
+			if (gui.isSingleClassTree()) {
 				deobfClasses.add(entry);
 				return;
 			}

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
@@ -60,7 +60,7 @@ public class Main {
 		parser.acceptsAll(List.of("edit-javadocs", "d"), "Enable editing Javadocs");
 		parser.acceptsAll(List.of("no-edit-javadocs", "D"), "Disable editing Javadocs");
 
-		parser.accepts("single-class-tree", "Shows all classes in the de-obfuscated panel");
+		parser.accepts("single-class-tree", "Unify the deobfuscated and obfuscated class panels");
 
 		parser.accepts("help", "Displays help information");
 
@@ -107,8 +107,12 @@ public class Main {
 			System.setProperty("apple.laf.useScreenMenuBar", "true");
 			Themes.setupTheme();
 
-			Gui gui = new Gui(parsedProfile, editables, options.has("single-class-tree"));
+			Gui gui = new Gui(parsedProfile, editables);
 			GuiController controller = gui.getController();
+			
+			if (options.has("single-class-tree")) {
+				gui.setSingleClassTree(true);
+			}
 
 			if (options.has(jar)) {
 				Path jarPath = options.valueOf(jar);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
@@ -60,6 +60,8 @@ public class Main {
 		parser.acceptsAll(List.of("edit-javadocs", "d"), "Enable editing Javadocs");
 		parser.acceptsAll(List.of("no-edit-javadocs", "D"), "Disable editing Javadocs");
 
+		parser.accepts("single-class-tree", "Shows all classes in the de-obfuscated panel");
+
 		parser.accepts("help", "Displays help information");
 
 		try {
@@ -105,7 +107,7 @@ public class Main {
 			System.setProperty("apple.laf.useScreenMenuBar", "true");
 			Themes.setupTheme();
 
-			Gui gui = new Gui(parsedProfile, editables);
+			Gui gui = new Gui(parsedProfile, editables, options.has("single-class-tree"));
 			GuiController controller = gui.getController();
 
 			if (options.has(jar)) {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/DeobfPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/DeobfPanel.java
@@ -32,7 +32,7 @@ public class DeobfPanel extends JPanel {
 	}
 
 	public void retranslateUi() {
-		this.title.setText(I18n.translate("info_panel.classes.deobfuscated"));
+		this.title.setText(I18n.translate(gui.isSingleClassTree() ? "info_panel.classes" : "info_panel.classes.deobfuscated"));
 	}
 
 }

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -90,6 +90,7 @@
 	"editor.decompile_error": "An error was encountered while decompiling.",
 	"editor.remap_error": "An error was encountered while remapping.",
 
+	"info_panel.classes": "Classes",
 	"info_panel.classes.obfuscated": "Obfuscated Classes",
 	"info_panel.classes.deobfuscated": "De-obfuscated Classes",
 	"info_panel.identifier": "Identifier Info",


### PR DESCRIPTION
Parchment uses a jar with already remapped classes, but Enigma puts them into panel with obf classes which sorts classes by length. This option puts all classes into the deobf panel, and completely hides the obf panel.