### PR TITLE
[Draft] Add RGS support, help needed with Enigma feature

### DIFF
--- a/enigma-swing/build.gradle
+++ b/enigma-swing/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application'
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id 'com.github.johnrengelman.shadow' version '7.0.0'
 }
 
 dependencies {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -78,6 +78,7 @@ public class Gui implements LanguageChangeListener {
 	public JFileChooser jarFileChooser;
 	public JFileChooser tinyMappingsFileChooser;
 	public JFileChooser enigmaMappingsFileChooser;
+	public JFileChooser rgsMappingsFileChooser;
 	public JFileChooser exportSourceFileChooser;
 	public JFileChooser exportJarFileChooser;
 	public SearchDialog searchDialog;
@@ -148,6 +149,10 @@ public class Gui implements LanguageChangeListener {
 		this.enigmaMappingsFileChooser = new JFileChooser();
 		this.enigmaMappingsFileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
 		this.enigmaMappingsFileChooser.setAcceptAllFileFilterUsed(false);
+
+		this.rgsMappingsFileChooser = new JFileChooser();
+		this.rgsMappingsFileChooser.setDialogTitle("Open RGS Mappings");
+		this.rgsMappingsFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
 
 		this.exportSourceFileChooser = new JFileChooser();
 		this.exportSourceFileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingPair.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingPair.java
@@ -17,6 +17,7 @@ public class MappingPair<E extends Entry<?>, M> {
 		this(entry, null);
 	}
 
+	@Nullable
 	public E getEntry() {
 		return entry;
 	}

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
@@ -6,6 +6,7 @@ import cuchaz.enigma.translation.mapping.MappingDelta;
 import cuchaz.enigma.translation.mapping.serde.enigma.EnigmaMappingsReader;
 import cuchaz.enigma.translation.mapping.serde.enigma.EnigmaMappingsWriter;
 import cuchaz.enigma.translation.mapping.serde.proguard.ProguardMappingsReader;
+import cuchaz.enigma.translation.mapping.serde.rgs.RGSReader;
 import cuchaz.enigma.translation.mapping.serde.srg.SrgMappingsWriter;
 import cuchaz.enigma.translation.mapping.serde.tiny.TinyMappingsReader;
 import cuchaz.enigma.translation.mapping.serde.tiny.TinyMappingsWriter;
@@ -24,7 +25,8 @@ public enum MappingFormat {
 	TINY_V2(new TinyV2Writer("intermediary", "named"), new TinyV2Reader()),
 	TINY_FILE(TinyMappingsWriter.INSTANCE, TinyMappingsReader.INSTANCE),
 	SRG_FILE(SrgMappingsWriter.INSTANCE, null),
-	PROGUARD(null, ProguardMappingsReader.INSTANCE);
+	PROGUARD(null, ProguardMappingsReader.INSTANCE),
+	RGS(null, RGSReader.INSTANCE);
 
 
 	private final MappingsWriter writer;

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
@@ -7,6 +7,7 @@ import cuchaz.enigma.translation.mapping.serde.enigma.EnigmaMappingsReader;
 import cuchaz.enigma.translation.mapping.serde.enigma.EnigmaMappingsWriter;
 import cuchaz.enigma.translation.mapping.serde.proguard.ProguardMappingsReader;
 import cuchaz.enigma.translation.mapping.serde.rgs.RGSReader;
+import cuchaz.enigma.translation.mapping.serde.rgs.RGSWriter;
 import cuchaz.enigma.translation.mapping.serde.srg.SrgMappingsWriter;
 import cuchaz.enigma.translation.mapping.serde.tiny.TinyMappingsReader;
 import cuchaz.enigma.translation.mapping.serde.tiny.TinyMappingsWriter;
@@ -26,7 +27,7 @@ public enum MappingFormat {
 	TINY_FILE(TinyMappingsWriter.INSTANCE, TinyMappingsReader.INSTANCE),
 	SRG_FILE(SrgMappingsWriter.INSTANCE, null),
 	PROGUARD(null, ProguardMappingsReader.INSTANCE),
-	RGS(null, RGSReader.INSTANCE);
+	RGS(RGSWriter.INSTANCE, RGSReader.INSTANCE);
 
 
 	private final MappingsWriter writer;

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSReader.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSReader.java
@@ -1,0 +1,101 @@
+package cuchaz.enigma.translation.mapping.serde.rgs;
+
+import com.google.common.base.Charsets;
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.MappingPair;
+import cuchaz.enigma.translation.mapping.serde.MappingParseException;
+import cuchaz.enigma.translation.mapping.serde.MappingSaveParameters;
+import cuchaz.enigma.translation.mapping.serde.MappingsReader;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.mapping.tree.HashEntryTree;
+import cuchaz.enigma.translation.representation.MethodDescriptor;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+public enum RGSReader implements MappingsReader {
+    INSTANCE;
+
+    @Override
+    public EntryTree<EntryMapping> read(Path path, ProgressListener progress, MappingSaveParameters saveParameters) throws MappingParseException, IOException {
+        return read(path, Files.readAllLines(path, Charsets.UTF_8), progress);
+    }
+
+    private EntryTree<EntryMapping> read(Path path, List<String> lines, ProgressListener progress) throws MappingParseException {
+        EntryTree<EntryMapping> mappings = new HashEntryTree<>();
+
+        for (int i = 0; i < lines.size(); i++) {
+            progress.step(i, "");
+            String line = lines.get(i).trim().replaceAll("\n\n+", "");
+
+            if (line.equals("") || line.startsWith("#") || line.startsWith(".option")) continue;
+
+            try {
+                MappingPair<?, EntryMapping> mapping = parseLine(line);
+                mappings.insert(mapping.getEntry(), mapping.getMapping());
+            } catch (Throwable t) {
+                t.printStackTrace();
+                throw new MappingParseException(path::toString, i, t.toString());
+            }
+        }
+
+        return mappings;
+    }
+
+    private MappingPair<?, EntryMapping> parseLine(String line) {
+        String[] tokens = line.split(" ");
+        String key = tokens[0];
+
+        switch (key) {
+            case ".class_map" -> { return parseClass(tokens); }
+            case ".field_map" -> { return parseField(tokens); }
+            case ".method_map" -> { return parseMethod(tokens); }
+            default -> throw new RuntimeException("Unknown token '" + key + "'!");
+        }
+    }
+
+    private MappingPair<ClassEntry, EntryMapping> parseClass(String[] tokens) {
+        // .class_map a PathPoint
+        ClassEntry obfuscatedEntry = new ClassEntry(tokens[1]);
+        String mapping = tokens[2];
+
+        // TODO: Do inner classes if those even exist in RGS
+        return new MappingPair<>(obfuscatedEntry, new EntryMapping(mapping));
+    }
+
+    private MappingPair<FieldEntry, EntryMapping> parseField(String[] tokens) {
+        // .field_map ad/e dataFolder
+        String obfuscatedClassAndFieldName = tokens[1];
+
+        int lastIndex = obfuscatedClassAndFieldName.lastIndexOf('/');
+        String obfuscatedClass = obfuscatedClassAndFieldName.substring(0, lastIndex);
+        String obfuscatedField = obfuscatedClassAndFieldName.substring(lastIndex);
+
+        ClassEntry ownerClass = new ClassEntry(obfuscatedClass);
+        FieldEntry obfuscatedEntry = new FieldEntry(ownerClass, obfuscatedField, null);
+        String mapping = tokens[2];
+
+        return new MappingPair<>(obfuscatedEntry, new EntryMapping(mapping));
+    }
+
+    private MappingPair<MethodEntry, EntryMapping> parseMethod(String[] tokens) {
+        // .method_map a/a ()Z func_1179_a
+        String obfuscatedClassAndMethodName = tokens[1];
+
+        int lastIndex = obfuscatedClassAndMethodName.lastIndexOf('/');
+        String obfuscatedClass = obfuscatedClassAndMethodName.substring(0, lastIndex);
+        String obfuscatedMethod = obfuscatedClassAndMethodName.substring(lastIndex);
+
+        ClassEntry ownerClass = new ClassEntry(obfuscatedClass);
+        MethodDescriptor ownerDescriptor = new MethodDescriptor(tokens[2]);
+        MethodEntry ownerMethod = new MethodEntry(ownerClass, obfuscatedMethod, ownerDescriptor);
+        String mapping = tokens[3];
+        return new MappingPair<>(null, new EntryMapping(mapping));
+    }
+}

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSReader.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSReader.java
@@ -39,8 +39,10 @@ public enum RGSReader implements MappingsReader {
 
         for (int i = 0; i < lines.size(); i++) {
             progress.step(i, "");
+            // This mainly removes empty lines which cause our reader to freak
             String line = lines.get(i).trim().replaceAll("\n\n+", "");
 
+            // This is needed to avoid preprocessor arguments, maybe there is a way to fix this?
             if (line.equals("") || line.startsWith("#") || line.startsWith(".option") || line.startsWith(".class ")) continue;
 
             try {
@@ -63,9 +65,12 @@ public enum RGSReader implements MappingsReader {
             case ".class_map" -> { return parseClass(tokens); }
             case ".field_map" -> { return parseField(tokens); }
             case ".method_map" -> { return parseMethod(tokens); }
+            // This is for JADs/RetroguardSrc version of intermediary (I.E. func_), our mappings will be a direct translation
+            // so everything else will have to be obfuscated, I could possibly "generate" intermediaries, but that's a
+            // feature as for now.
             case "### GENERATED MAPPINGS:" -> {
                 this.isGeneratedIntermediaries = true;
-                return parseField(tokens);
+                return null;
             }
             default -> throw new RuntimeException("Unknown token '" + key + "'!");
         }

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSReader.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSReader.java
@@ -10,6 +10,7 @@ import cuchaz.enigma.translation.mapping.serde.MappingsReader;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
 import cuchaz.enigma.translation.mapping.tree.HashEntryTree;
 import cuchaz.enigma.translation.representation.MethodDescriptor;
+import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.FieldEntry;
 import cuchaz.enigma.translation.representation.entry.MethodEntry;
@@ -34,7 +35,7 @@ public enum RGSReader implements MappingsReader {
             progress.step(i, "");
             String line = lines.get(i).trim().replaceAll("\n\n+", "");
 
-            if (line.equals("") || line.startsWith("#") || line.startsWith(".option")) continue;
+            if (line.equals("") || line.startsWith("#") || line.startsWith(".option") || line.startsWith(".class ")) continue;
 
             try {
                 MappingPair<?, EntryMapping> mapping = parseLine(line);
@@ -75,10 +76,10 @@ public enum RGSReader implements MappingsReader {
 
         int lastIndex = obfuscatedClassAndFieldName.lastIndexOf('/');
         String obfuscatedClass = obfuscatedClassAndFieldName.substring(0, lastIndex);
-        String obfuscatedField = obfuscatedClassAndFieldName.substring(lastIndex);
+        String obfuscatedField = obfuscatedClassAndFieldName.substring(lastIndex + 1);
 
         ClassEntry ownerClass = new ClassEntry(obfuscatedClass);
-        FieldEntry obfuscatedEntry = new FieldEntry(ownerClass, obfuscatedField, null);
+        FieldEntry obfuscatedEntry = new FieldEntry(ownerClass, obfuscatedField, new TypeDescriptor("LStepSound;"));
         String mapping = tokens[2];
 
         return new MappingPair<>(obfuscatedEntry, new EntryMapping(mapping));
@@ -90,12 +91,12 @@ public enum RGSReader implements MappingsReader {
 
         int lastIndex = obfuscatedClassAndMethodName.lastIndexOf('/');
         String obfuscatedClass = obfuscatedClassAndMethodName.substring(0, lastIndex);
-        String obfuscatedMethod = obfuscatedClassAndMethodName.substring(lastIndex);
+        String obfuscatedMethod = obfuscatedClassAndMethodName.substring(lastIndex + 1);
 
         ClassEntry ownerClass = new ClassEntry(obfuscatedClass);
         MethodDescriptor ownerDescriptor = new MethodDescriptor(tokens[2]);
         MethodEntry ownerMethod = new MethodEntry(ownerClass, obfuscatedMethod, ownerDescriptor);
         String mapping = tokens[3];
-        return new MappingPair<>(null, new EntryMapping(mapping));
+        return new MappingPair<>(ownerMethod, new EntryMapping(mapping));
     }
 }

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSWriter.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSWriter.java
@@ -1,0 +1,111 @@
+package cuchaz.enigma.translation.mapping.serde.rgs;
+
+import com.google.common.collect.Lists;
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.translation.MappingTranslator;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.MappingDelta;
+import cuchaz.enigma.translation.mapping.VoidEntryResolver;
+import cuchaz.enigma.translation.mapping.serde.LfPrintWriter;
+import cuchaz.enigma.translation.mapping.serde.MappingSaveParameters;
+import cuchaz.enigma.translation.mapping.serde.MappingsWriter;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import cuchaz.enigma.utils.I18n;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+public enum RGSWriter implements MappingsWriter {
+    INSTANCE;
+
+    private Collection<Entry<?>> sorted(Iterable<? extends Entry<?>> iterable) {
+        ArrayList<Entry<?>> sorted = Lists.newArrayList(iterable);
+        sorted.sort(Comparator.comparing(Entry::getName));
+        return sorted;
+    }
+
+    @Override
+    public void write(EntryTree<EntryMapping> mappings, MappingDelta<EntryMapping> delta, Path path, ProgressListener progress, MappingSaveParameters saveParameters) {
+        try {
+            Files.deleteIfExists(path);
+            Files.createFile(path);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        List<String> classLines = new ArrayList<>();
+        List<String> fieldLines = new ArrayList<>();
+        List<String> methodLines = new ArrayList<>();
+
+        List<? extends Entry<?>> rootEntries = Lists.newArrayList(mappings).stream()
+                .map(EntryTreeNode::getEntry)
+                .toList();
+        progress.init(rootEntries.size(), I18n.translate("progress.mappings.rgs_file.generating"));
+
+        int steps = 0;
+        for (Entry<?> entry : sorted(rootEntries)) {
+            progress.step(steps++, entry.getName());
+            writeEntry(classLines, fieldLines, methodLines, mappings, entry);
+        }
+
+        progress.init(3, I18n.translate("progress.mappings.rgs_file.writing"));
+        try (PrintWriter writer = new LfPrintWriter(Files.newBufferedWriter(path))) {
+            progress.step(0, I18n.translate("type.classes"));
+            classLines.forEach(writer::println);
+            progress.step(1, I18n.translate("type.fields"));
+            fieldLines.forEach(writer::println);
+            progress.step(2, I18n.translate("type.methods"));
+            methodLines.forEach(writer::println);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    private void writeEntry(List<String> classes, List<String> fields, List<String> methods, EntryTree<EntryMapping> mappings, Entry<?> entry) {
+        EntryTreeNode<EntryMapping> node = mappings.findNode(entry);
+        if (node == null) {
+            return;
+        }
+
+        Translator translator = new MappingTranslator(mappings, VoidEntryResolver.INSTANCE);
+        if (entry instanceof ClassEntry) {
+            classes.add(generateClassLine((ClassEntry) entry, translator));
+        } else if (entry instanceof FieldEntry) {
+            fields.add(generateFieldLine((FieldEntry) entry, translator));
+        } else if (entry instanceof MethodEntry) {
+            methods.add(generateMethodLine((MethodEntry) entry, translator));
+        }
+
+        for (Entry<?> child : sorted(node.getChildren())) {
+            writeEntry(classes, fields, methods, mappings, child);
+        }
+    }
+
+    private String generateClassLine(ClassEntry entry, Translator translator) {
+        ClassEntry targetEntry = translator.translate(entry);
+        return ".class_map " + entry.getFullName().replaceAll("\\.", "/") + " " + targetEntry.getName();
+    }
+
+    private String generateFieldLine(FieldEntry entry, Translator translator) {
+        FieldEntry targetEntry = translator.translate(entry);
+        return ".field_map " + entry.getFullName().replaceAll("\\.", "/") + " " + targetEntry.getName();
+    }
+
+    private String generateMethodLine(MethodEntry entry, Translator translator) {
+        MethodEntry targetEntry = translator.translate(entry);
+        return ".method_map " + entry.getFullName().replaceAll("\\.", "/") + " " + entry.getDesc() + " " + targetEntry.getName();
+    }
+}

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSWriter.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSWriter.java
@@ -81,12 +81,16 @@ public enum RGSWriter implements MappingsWriter {
         }
 
         Translator translator = new MappingTranslator(mappings, VoidEntryResolver.INSTANCE);
-        if (entry instanceof ClassEntry) {
-            classes.add(generateClassLine((ClassEntry) entry, translator));
-        } else if (entry instanceof FieldEntry) {
-            fields.add(generateFieldLine((FieldEntry) entry, translator));
-        } else if (entry instanceof MethodEntry) {
-            methods.add(generateMethodLine((MethodEntry) entry, translator));
+        if (entry instanceof ClassEntry classEntry) {
+            if (!classEntry.getFullName().contains("paulscode") && !classEntry.getName().equals("net/minecraft/client/MinecraftApplet") && !classEntry.getName().equals("net/minecraft/isom/IsomPreviewApplet") && !classEntry.getName().equals("net/minecraft/client/Minecraft")) {
+                classes.add(generateClassLine(classEntry, translator));
+            }
+        } else if (entry instanceof FieldEntry fieldEntry) {
+            fields.add(generateFieldLine(fieldEntry, translator));
+        } else if (entry instanceof MethodEntry methodEntry) {
+            if (!entry.getName().contains("<init>")) {
+                methods.add(generateMethodLine(methodEntry, translator));
+            }
         }
 
         for (Entry<?> child : sorted(node.getChildren())) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSWriter.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/rgs/RGSWriter.java
@@ -62,6 +62,13 @@ public enum RGSWriter implements MappingsWriter {
 
         progress.init(3, I18n.translate("progress.mappings.rgs_file.writing"));
         try (PrintWriter writer = new LfPrintWriter(Files.newBufferedWriter(path))) {
+            // Preprocessor arguments, Alpha 1.1.2_01 RGS parser freaks if these do not exist
+            writer.write(".option Application\n");
+            writer.write(".class paulscode/sound/** protected\n");
+            writer.write(".class com/jcraft/** protected\n");
+            writer.write(".class *\n");
+            writer.write(".class net/minecraft/**\n");
+
             progress.step(0, I18n.translate("type.classes"));
             classLines.forEach(writer::println);
             progress.step(1, I18n.translate("type.fields"));
@@ -82,12 +89,14 @@ public enum RGSWriter implements MappingsWriter {
 
         Translator translator = new MappingTranslator(mappings, VoidEntryResolver.INSTANCE);
         if (entry instanceof ClassEntry classEntry) {
+            // RGS parser freaks if any of these classes are in the output.
             if (!classEntry.getFullName().contains("paulscode") && !classEntry.getName().equals("net/minecraft/client/MinecraftApplet") && !classEntry.getName().equals("net/minecraft/isom/IsomPreviewApplet") && !classEntry.getName().equals("net/minecraft/client/Minecraft")) {
                 classes.add(generateClassLine(classEntry, translator));
             }
         } else if (entry instanceof FieldEntry fieldEntry) {
             fields.add(generateFieldLine(fieldEntry, translator));
         } else if (entry instanceof MethodEntry methodEntry) {
+            // RGS parser doesn't like constructors being mapped like methods as <init>
             if (!entry.getName().contains("<init>")) {
                 methods.add(generateMethodLine(methodEntry, translator));
             }

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
@@ -14,6 +14,7 @@ package cuchaz.enigma.translation.representation.entry;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 
@@ -34,12 +35,12 @@ public class FieldEntry extends ParentedEntry<ClassEntry> implements Comparable<
 		super(parent, name, javadocs);
 
 		Preconditions.checkNotNull(parent, "Owner cannot be null");
-		Preconditions.checkNotNull(desc, "Field descriptor cannot be null");
+		//Preconditions.checkNotNull(desc, "Field descriptor cannot be null");
 
 		this.desc = desc;
 	}
 
-	public static FieldEntry parse(String owner, String name, String desc) {
+	public static FieldEntry parse(String owner, String name, @Nullable String desc) {
 		return new FieldEntry(new ClassEntry(owner), name, new TypeDescriptor(desc), null);
 	}
 
@@ -48,6 +49,7 @@ public class FieldEntry extends ParentedEntry<ClassEntry> implements Comparable<
 		return ClassEntry.class;
 	}
 
+	@Nullable
 	public TypeDescriptor getDesc() {
 		return this.desc;
 	}

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -151,6 +151,8 @@
 	"progress.mappings.tiny_v2.loading": "Loading mapping file",
 	"progress.mappings.srg_file.generating": "Generating mappings",
 	"progress.mappings.srg_file.writing": "Writing mappings",
+	"progress.mappings.rgs_file.generating": "Generating mappings",
+	"progress.mappings.rgs_file.writing": "Writing mappings",
 	"progress.stats": "Generating stats",
 	"progress.stats.data": "Generating data",
 

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -8,6 +8,7 @@
 	"mapping_format.tiny_file": "Tiny File",
 	"mapping_format.srg_file": "SRG File",
 	"mapping_format.proguard": "Proguard",
+	"mapping_format.rgs": "RGS",
 	"type.methods": "Methods",
 	"type.fields": "Fields",
 	"type.parameters": "Parameters",


### PR DESCRIPTION
A Modification Station member asked me about how to convert RGS to Tiny and vice versa, and I told him it was possible with some string manipulation. Eventually, he decided to ask me if I could make a plugin to Enigma to allow for this feature. I since have made an exporter and an importer, but the importer is bugged due to RGS not containing field signatures/type descriptors. I propose either a way to pass in `null` as for the type descriptor, or to allow direct access to the JAR file used to obtain descriptors.

Any comments / proposals / changes are welcome.

RGS uses three main operators for classes, methods, and fields, being respectively:
`.class_map obfuscatedClass remappedClass`
`.field_map obfuscatedClass/obfuscatedFieldName remappedFieldName` // Note that type descriptor is missing
`.method_map obfuscatedClass/obfuscatedMethodName typeDescriptor remappedMethodName`

Comments are done with # and preprocessor arguments such as `.option Application` are prefixed with dot.