### PR TITLE
Record handling improvements

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/GuiUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/GuiUtil.java
@@ -20,6 +20,7 @@ import javax.swing.tree.TreePath;
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 import com.google.common.collect.Lists;
 
+import cuchaz.enigma.analysis.index.EntryIndex;
 import cuchaz.enigma.gui.Gui;
 import cuchaz.enigma.translation.representation.AccessFlags;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
@@ -119,7 +120,8 @@ public class GuiUtil {
     }
 
     public static Icon getClassIcon(Gui gui, ClassEntry entry) {
-        AccessFlags access = gui.getController().project.getJarIndex().getEntryIndex().getClassAccess(entry);
+        EntryIndex entryIndex = gui.getController().project.getJarIndex().getEntryIndex();
+        AccessFlags access = entryIndex.getClassAccess(entry);
 
         if (access != null) {
             if (access.isAnnotation()) {
@@ -128,7 +130,7 @@ public class GuiUtil {
                 return INTERFACE_ICON;
             } else if (access.isEnum()) {
                 return ENUM_ICON;
-            } else if (access.isRecord()) {
+            } else if (entryIndex.getDefinition(entry).isRecord()) {
                 return RECORD_ICON;
             }
         }

--- a/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
@@ -150,7 +150,7 @@ public class EnigmaDumper extends StringStreamDumper {
 
                     String javaDoc = mapping.javadoc();
                     if (javaDoc != null) {
-                        recordComponentDocs.add(String.format("@param %s %s", field.getFieldName(), javaDoc));
+                        recordComponentDocs.add(String.format("@param %s %s", mapping.targetName(), javaDoc));
                     }
                 }
             }

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/EntryRemapper.java
@@ -88,9 +88,9 @@ public class EntryRemapper {
 		}
 	}
 
-	// A little bit of a hack to also map the getter method for record fields/components.
+	// A little bit of a hack to also map the getter method for record fields.
 	private void mapRecordComponentGetter(ValidationContext vc, ClassEntry classEntry, FieldEntry fieldEntry, EntryMapping fieldMapping) {
-		if (!jarIndex.getEntryIndex().getClassAccess(classEntry).isRecord() || jarIndex.getEntryIndex().getFieldAccess(fieldEntry).isStatic()) {
+		if (!jarIndex.getEntryIndex().getDefinition(classEntry).isRecord() || jarIndex.getEntryIndex().getFieldAccess(fieldEntry).isStatic()) {
 			return;
 		}
 
@@ -102,7 +102,7 @@ public class EntryRemapper {
 		MethodEntry methodEntry = null;
 
 		for (MethodEntry method : classMethods) {
-			// Find the matching record component getter via matching the names. My understanding is this is safe, failing this it may need to be a bit more intelligent
+			// Find the matching record component getter via matching the names. TODO: Support when the record field and method names do not match
 			if (method.getName().equals(fieldEntry.getName()) && method.getDesc().toString().equals("()" + fieldEntry.getDesc())) {
 				methodEntry = method;
 				break;
@@ -114,7 +114,8 @@ public class EntryRemapper {
 			return;
 		}
 
-		putMapping(vc, methodEntry, fieldMapping != null ? new EntryMapping(fieldMapping.targetName()) : null);
+		// Also remap the associated method, without the javadoc.
+		doPutMapping(vc, methodEntry, new EntryMapping(fieldMapping.targetName()), false);
 	}
 
 	@Nonnull

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/AccessFlags.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/AccessFlags.java
@@ -39,10 +39,6 @@ public class AccessFlags {
 		return (flags & Opcodes.ACC_ENUM) != 0;
 	}
 
-	public boolean isRecord() {
-		return (flags & Opcodes.ACC_RECORD) != 0;
-	}
-
 	public boolean isBridge() {
 		return (flags & Opcodes.ACC_BRIDGE) != 0;
 	}

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassDefEntry.java
@@ -75,6 +75,10 @@ public class ClassDefEntry extends ClassEntry implements DefEntry<ClassEntry> {
 		return interfaces;
 	}
 
+	public boolean isRecord() {
+		return superClass.getName().equals("java/lang/Record");
+	}
+
 	@Override
 	public TranslateResult<ClassDefEntry> extendedTranslate(Translator translator, @Nonnull EntryMapping mapping) {
 		Signature translatedSignature = translator.translate(signature);


### PR DESCRIPTION
- Improve record class detection, the access flag is only added by ASM when it finds a record atribute on the class, we now use the super class.
- Also generate a method mapping for the record entry, does not support the case of the method having a diffrent name from the field. This needs looking at, but is not an issue for yarn as it will be ran ontop of an intermediary named jar.
- If there is a record component this is stilled remapped via the field mapping.