### PR TITLE
Change Constructor icon colour to be more distinct from Class

### DIFF
--- a/enigma-swing/src/main/resources/icons/constructor.svg
+++ b/enigma-swing/src/main/resources/icons/constructor.svg
@@ -25,7 +25,7 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="44.9375"
-     inkscape:cx="7.6884562"
+     inkscape:cx="7.3991655"
      inkscape:cy="8"
      inkscape:window-width="1920"
      inkscape:window-height="1137"
@@ -109,7 +109,7 @@
   <g
      id="layer1">
     <rect
-       style="fill:#d21928;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none"
+       style="fill:#1925d2;fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none"
        id="rect18"
        width="4.2333331"
        height="4.2333331"
@@ -117,7 +117,7 @@
        y="0"
        ry="1.0583333" />
     <rect
-       style="fill:#f3213f;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#213bf3;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect847"
        width="3.7041667"
        height="3.7041667"


### PR DESCRIPTION
Successor to #436 
As they're both 'C's, having them both be different reds was... less than ideal.
Now Constructor is Dark Blue, which also emphasizes its relationship to Method which is light blue