### PR TITLE
Make enum methods `values` and `valueOf` unmappable

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -18,9 +18,6 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
-import cuchaz.enigma.api.service.ObfuscationTestService;
-import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
-import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
 
@@ -41,6 +38,7 @@ import cuchaz.enigma.translation.mapping.EntryRemapper;
 import cuchaz.enigma.translation.mapping.MappingsChecker;
 import cuchaz.enigma.translation.mapping.tree.DeltaTrackingTree;
 import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.translation.representation.entry.LocalVariableEntry;
@@ -155,6 +153,7 @@ public class EnigmaProject {
 				return false;
 			} else {
 				ClassDefEntry parent = jarIndex.getEntryIndex().getDefinition(obfMethodEntry.getParent());
+
 				if (parent != null && parent.getSuperClass() != null && parent.getSuperClass().getFullName().equals("java/lang/Enum")) {
 					if (name.equals("values") && sig.equals("()[L" + parent.getFullName() + ";")) {
 						return false;

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -18,6 +18,9 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
+import cuchaz.enigma.api.service.ObfuscationTestService;
+import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
+import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
 
@@ -150,6 +153,15 @@ public class EnigmaProject {
 				return false;
 			} else if (name.equals("wait") && sig.equals("(JI)V")) {
 				return false;
+			} else {
+				ClassDefEntry parent = jarIndex.getEntryIndex().getDefinition(obfMethodEntry.getParent());
+				if (parent != null && parent.getSuperClass() != null && parent.getSuperClass().getFullName().equals("java/lang/Enum")) {
+					if (name.equals("values") && sig.equals("()[L" + parent.getFullName() + ";")) {
+						return false;
+					} else if (name.equals("valueOf") && sig.equals("(Ljava/lang/String;)L" + parent.getFullName() + ";")) {
+						return false;
+					}
+				}
 			}
 		} else if (obfEntry instanceof LocalVariableEntry && !((LocalVariableEntry) obfEntry).isArgument()) {
 			return false;

--- a/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
@@ -273,7 +273,8 @@ public class EnigmaDumper extends StringStreamDumper {
 		int now = sb.length();
 		Token token = new Token(now - name.length(), now, name);
 
-		if (entry != null) {
+		// Skip constructor references
+		if (entry != null && !name.equals("new")) {
 			if (defines) {
 				index.addDeclaration(token, entry); // override as cfr reuses local vars
 			} else {

--- a/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
@@ -273,8 +273,7 @@ public class EnigmaDumper extends StringStreamDumper {
 		int now = sb.length();
 		Token token = new Token(now - name.length(), now, name);
 
-		// Skip constructor references
-		if (entry != null && !name.equals("new")) {
+		if (entry != null) {
 			if (defines) {
 				index.addDeclaration(token, entry); // override as cfr reuses local vars
 			} else {


### PR DESCRIPTION
Taken from https://github.com/QuiltMC/enigma/commit/fe9c232b65beb7e27964a92c1dc55509de4da127, https://github.com/QuiltMC/enigma/commit/1d8067cf6526223a9efa74e83d22addd529a4289 ~~and https://github.com/QuiltMC/enigma/commit/226d5b03b4145b8675b1b5dbffc153eb88e97db1~~.

Fixes #330.