### PR TITLE
Fix constructor references being remapped

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/cfr/EnigmaDumper.java
@@ -273,7 +273,8 @@ public class EnigmaDumper extends StringStreamDumper {
 		int now = sb.length();
 		Token token = new Token(now - name.length(), now, name);
 
-		if (entry != null) {
+		// Skip constructor references
+		if (entry != null && !name.equals("new")) {
 			if (defines) {
 				index.addDeclaration(token, entry); // override as cfr reuses local vars
 			} else {


### PR DESCRIPTION
Taken from https://github.com/QuiltMC/enigma/commit/226d5b03b4145b8675b1b5dbffc153eb88e97db1. Partly supersedes #470.

> As of now, references to mapped constructors appear as `ExampleClass::ExampleClass` instead of `ExampleClass::new`. Obfuscated classes appear correctly as `a::new`.