### PR TITLE
fix UTF8 character bug

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/source/cfr/CfrDecompiler.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/cfr/CfrDecompiler.java
@@ -26,7 +26,7 @@ public class CfrDecompiler implements Decompiler {
 	private final ClassFileSource2 classFileSource;
 
 	public CfrDecompiler(ClassProvider classProvider, SourceSettings sourceSettings) {
-		this.options = OptionsImpl.getFactory().create(Map.of("trackbytecodeloc", "true"));
+		this.options = OptionsImpl.getFactory().create(Map.of("trackbytecodeloc", "true", "hideutf", "false"));
 		this.settings = sourceSettings;
 		this.classFileSource = new ClassFileSource(classProvider);
 	}


### PR DESCRIPTION
#497 
The characters in the token were escaped in the source, but I fixed it by setting convertUTF of EnigmaDumper to false.

token:
![image](https://user-images.githubusercontent.com/82015149/221070117-dd53ba61-b8b4-4229-b105-1003b499d149.png)
source:
![image](https://user-images.githubusercontent.com/82015149/221070136-2eeda275-3e51-43da-a10d-5d56648477fd.png)

I set convertUTF in EnigmaDumper to false to fix it.

token:
![image](https://user-images.githubusercontent.com/82015149/221071305-7b5803eb-3bcd-4a80-b07f-20a0d0a5b536.png)
source:
![image](https://user-images.githubusercontent.com/82015149/221071302-6fca468d-286e-4544-8aef-9a2bd2b7a449.png)
