### PR TITLE
Fix NullPointerException in mapping stats when package name is null

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/stats/StatsGenerator.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/stats/StatsGenerator.java
@@ -66,8 +66,9 @@ public class StatsGenerator {
 						.findFirst()
 						.orElseThrow(AssertionError::new);
 				ClassEntry clazz = root.getParent();
+				final String packageName = this.mapper.deobfuscate(clazz).getPackageName();
 
-				if (root == method && this.mapper.deobfuscate(clazz).getPackageName().startsWith(topLevelPackageSlash)) {
+				if (root == method && packageName != null && packageName.startsWith(topLevelPackageSlash)) {
 					if (includedMembers.contains(StatsMember.METHODS) && !((MethodDefEntry) method).getAccess().isSynthetic()) {
 						update(counts, method);
 						totalMappable++;
@@ -90,8 +91,9 @@ public class StatsGenerator {
 			for (FieldEntry field : entryIndex.getFields()) {
 				progress.step(numDone++, I18n.translate("type.fields"));
 				ClassEntry clazz = field.getParent();
+				final String packageName = this.mapper.deobfuscate(clazz).getPackageName();
 
-				if (!((FieldDefEntry) field).getAccess().isSynthetic() && this.mapper.deobfuscate(clazz).getPackageName().startsWith(topLevelPackageSlash)) {
+				if (!((FieldDefEntry) field).getAccess().isSynthetic() && packageName != null && packageName.startsWith(topLevelPackageSlash)) {
 					update(counts, field);
 					totalMappable++;
 				}


### PR DESCRIPTION
[26ba5a5](https://github.com/FabricMC/Enigma/commit/26ba5a59976a8b4a5e9d71d52f5a13a2aa2882de) originally fixed this issue (#503) but the exceptions persists when the package name is null. This PR attempts to fix that.