### PR TITLE
Fix `canConflictWith` check for fields

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
@@ -85,7 +85,7 @@ public class FieldEntry extends ParentedEntry<ClassEntry> implements Comparable<
 
 	@Override
 	public boolean canConflictWith(Entry<?> entry) {
-		return false;
+		return entry instanceof FieldEntry fieldEntry && fieldEntry.getParent().equals(parent);
 	}
 
 	@Override


### PR DESCRIPTION
It has been accidentally removed in #475. Seems like I was a bit too careless when copying over commits from team pineapple.