### PR TITLE
Fix ghost entries caused by packages becoming empty

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/NestedPackages.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/NestedPackages.java
@@ -88,10 +88,10 @@ public class NestedPackages {
 		ClassSelectorClassNode node = classToNode.remove(entry);
 
 		if (node != null) {
+			DefaultMutableTreeNode packageNode = (DefaultMutableTreeNode) node.getParent();
 			node.removeFromParent();
+			
 			// remove dangling packages
-			DefaultMutableTreeNode packageNode = packageToNode.get(entry.getPackageName());
-
 			while (packageNode != null && packageNode.getChildCount() == 0) {
 				DefaultMutableTreeNode theNode = packageNode;
 				packageNode = (DefaultMutableTreeNode) packageNode.getParent();

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/NestedPackages.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/NestedPackages.java
@@ -90,7 +90,7 @@ public class NestedPackages {
 		if (node != null) {
 			DefaultMutableTreeNode packageNode = (DefaultMutableTreeNode) node.getParent();
 			node.removeFromParent();
-			
+
 			// remove dangling packages
 			while (packageNode != null && packageNode.getChildCount() == 0) {
 				DefaultMutableTreeNode theNode = packageNode;


### PR DESCRIPTION
Fixes #471. The current code's issue is that `entry.getPackageName()` here: https://github.com/FabricMC/Enigma/blob/08d9e28bdc00ac7846e551e5eef7ebf9ffc63b74/enigma-swing/src/main/java/cuchaz/enigma/gui/NestedPackages.java#L92-L93
already returns the new package name, not the old one, which is required. We can circumvent this by simply using the UI node's parent instead, which still points to the old entry.