### PR TITLE
Allow using ctrl-shift-4 to close all open tabs

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/EditorTabPopupMenu.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/EditorTabPopupMenu.java
@@ -30,6 +30,7 @@ public class EditorTabPopupMenu {
 
 		this.closeAll = new JMenuItem();
 		this.closeAll.addActionListener(a -> pane.closeAllEditorTabs());
+		this.closeAll.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_4, KeyEvent.CTRL_DOWN_MASK + KeyEvent.SHIFT_DOWN_MASK));
 		this.ui.add(this.closeAll);
 
 		this.closeOthers = new JMenuItem();


### PR DESCRIPTION
This PR makes the `CTRL` + `SHIFT` + `4` key combo close all editor tabs, similar to how browsers handle `CTRL` + `W` and `CTRL` + `SHIFT` + `W`.