### PR TITLE
Fix StatsGenerator encoding

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -15,6 +15,7 @@ import java.awt.Desktop;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -556,7 +557,7 @@ public class GuiController implements ClientPacketHandler {
 			try {
 				File statsFile = File.createTempFile("stats", ".html");
 
-				try (FileWriter w = new FileWriter(statsFile)) {
+				try (FileWriter w = new FileWriter(statsFile, StandardCharsets.UTF_8)) {
 					w.write(Utils.readResourceToString("/stats.html").replace("/*data*/", data));
 				}
 


### PR DESCRIPTION
Fixes  #523.

```diff
- try (FileWriter w = new FileWriter(statsFile)) {
+ try (FileWriter w = new FileWriter(statsFile, StandardCharsets.UTF_8)) {
```

before:
![image](https://github.com/FabricMC/Enigma/assets/82015149/913f712b-bace-46bc-81a7-8f8dafaab094)
![image](https://github.com/FabricMC/Enigma/assets/82015149/c2a92173-65fa-4b99-9028-67b99d1721ca)
after:
![image](https://github.com/FabricMC/Enigma/assets/82015149/c4c7f2cd-9f7a-4bb0-9e50-c55c17ce5853)