### PR TITLE
Fix documenting constructors (again)

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -38,6 +38,7 @@ import cuchaz.enigma.gui.elements.ValidatableTextArea;
 import cuchaz.enigma.gui.util.GuiUtil;
 import cuchaz.enigma.gui.util.ScaleUtil;
 import cuchaz.enigma.translation.mapping.EntryChange;
+import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.utils.I18n;
 import cuchaz.enigma.utils.validation.ValidationContext;
@@ -195,8 +196,8 @@ public class JavadocDialog {
 	}
 
 	public static void show(JFrame parent, GuiController controller, EntryReference<Entry<?>, Entry<?>> entry) {
-		EntryReference<Entry<?>, Entry<?>> translatedReference = controller.project.getMapper().deobfuscate(entry);
-		String text = Strings.nullToEmpty(translatedReference.entry.getJavadocs());
+		EntryMapping mapping = controller.project.getMapper().getDeobfMapping(entry.entry);
+		String text = Strings.nullToEmpty(mapping.javadoc());
 
 		JavadocDialog dialog = new JavadocDialog(parent, controller, entry.entry, text);
 		//dialog.ui.doLayout();

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -196,9 +196,12 @@ public class JavadocDialog {
 	}
 
 	public static void show(JFrame parent, GuiController controller, EntryReference<Entry<?>, Entry<?>> entry) {
+		// Get the existing text through the mapping as it works for all entries, including constructors.
 		EntryMapping mapping = controller.project.getMapper().getDeobfMapping(entry.entry);
 		String text = Strings.nullToEmpty(mapping.javadoc());
 
+		// Note: entry.entry is used instead of getNameableEntry() to include constructors,
+		// which can be documented.
 		JavadocDialog dialog = new JavadocDialog(parent, controller, entry.entry, text);
 		//dialog.ui.doLayout();
 		dialog.ui.setVisible(true);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -198,7 +198,7 @@ public class JavadocDialog {
 		EntryReference<Entry<?>, Entry<?>> translatedReference = controller.project.getMapper().deobfuscate(entry);
 		String text = Strings.nullToEmpty(translatedReference.entry.getJavadocs());
 
-		JavadocDialog dialog = new JavadocDialog(parent, controller, entry.getNameableEntry(), text);
+		JavadocDialog dialog = new JavadocDialog(parent, controller, entry.entry, text);
 		//dialog.ui.doLayout();
 		dialog.ui.setVisible(true);
 		dialog.text.grabFocus();


### PR DESCRIPTION
Fixes #200, which was reintroduced at some point.

The fix is modelled after
1. My original PR #201 (using `entry` instead of `getNameableEntry()`, since the latter specifically only excludes constructors)
2. The CFR bridge code's `EnigmaDumper`, which always uses `EntryMapping` to access javadoc