### PR TITLE
Index more class references

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexReferenceVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexReferenceVisitor.java
@@ -112,6 +112,11 @@ public class IndexReferenceVisitor extends ClassVisitor {
 				indexer.indexClassReference(callerEntry, ClassEntry.parse(type.desc), ReferenceTargetType.none());
 			}
 
+			if (insn.getOpcode() == Opcodes.CHECKCAST) {
+				TypeInsnNode type = (TypeInsnNode) insn;
+				indexer.indexClassReference(callerEntry, ClassEntry.parse(type.desc), ReferenceTargetType.none());
+			}
+
 			return super.unaryOperation(insn, value);
 		}
 

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexReferenceVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexReferenceVisitor.java
@@ -84,6 +84,7 @@ public class IndexReferenceVisitor extends ClassVisitor {
 
 			if (insn.getOpcode() == Opcodes.LDC) {
 				LdcInsnNode ldc = (LdcInsnNode) insn;
+
 				if (ldc.getType() == Type.ARRAY && ldc.cst instanceof Type type) {
 					String className = type.getClassName().replace(".", "/");
 					indexer.indexClassReference(callerEntry, ClassEntry.parse(className), ReferenceTargetType.none());

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
@@ -153,6 +153,15 @@ public class JarIndex implements JarIndexer {
 	}
 
 	@Override
+	public void indexClassReference(MethodDefEntry callerEntry, ClassEntry referencedEntry, ReferenceTargetType targetType) {
+		if (callerEntry.getParent().isJre()) {
+			return;
+		}
+
+		indexers.forEach(indexer -> indexer.indexClassReference(callerEntry, referencedEntry, targetType));
+	}
+
+	@Override
 	public void indexMethodReference(MethodDefEntry callerEntry, MethodEntry referencedEntry, ReferenceTargetType targetType) {
 		if (callerEntry.getParent().isJre()) {
 			return;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndexer.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndexer.java
@@ -3,6 +3,7 @@ package cuchaz.enigma.analysis.index;
 import cuchaz.enigma.analysis.ReferenceTargetType;
 import cuchaz.enigma.translation.representation.Lambda;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.FieldDefEntry;
 import cuchaz.enigma.translation.representation.entry.FieldEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
@@ -16,6 +17,9 @@ public interface JarIndexer {
 	}
 
 	default void indexMethod(MethodDefEntry methodEntry) {
+	}
+
+	default void indexClassReference(MethodDefEntry callerEntry, ClassEntry referencedEntry, ReferenceTargetType targetType) {
 	}
 
 	default void indexMethodReference(MethodDefEntry callerEntry, MethodEntry referencedEntry, ReferenceTargetType targetType) {

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/ReferenceIndex.java
@@ -65,6 +65,11 @@ public class ReferenceIndex implements JarIndexer {
 	}
 
 	@Override
+	public void indexClassReference(MethodDefEntry callerEntry, ClassEntry referencedEntry, ReferenceTargetType targetType) {
+		referencesToClasses.put(referencedEntry, new EntryReference<>(referencedEntry, referencedEntry.getName(), callerEntry, targetType));
+	}
+
+	@Override
 	public void indexMethodReference(MethodDefEntry callerEntry, MethodEntry referencedEntry, ReferenceTargetType targetType) {
 		referencesToMethods.put(referencedEntry, new EntryReference<>(referencedEntry, referencedEntry.getName(), callerEntry, targetType));
 		methodReferences.put(callerEntry, referencedEntry);

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -50,6 +50,10 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 		}
 	}
 
+	public static ClassEntry parse(String name) {
+		return new ClassEntry(name);
+	}
+
 	@Override
 	public Class<ClassEntry> getParentType() {
 		return ClassEntry.class;


### PR DESCRIPTION
Until now, Enigma only indexed class references through constructor methods. With this PR, it now indexes class references in 3 more ways:
- When used in `instanceof`
- When used in a cast
- When the class itself is called (`MyClass.class`), which fixes #26 