### PR TITLE
Fix editor scaling

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/UiConfig.java
@@ -276,7 +276,7 @@ public final class UiConfig {
 	 * @return the fallback editor font
 	 */
 	public static Font getFallbackEditorFont() {
-		return ScaleUtil.scaleFont(Font.decode(Font.MONOSPACED));
+		return ScaleUtil.scaleFont(Font.decode(Font.MONOSPACED).deriveFont(12f));
 	}
 
 	public static String encodeFont(Font font) {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
@@ -20,6 +20,8 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.Highlighter;
 import javax.swing.text.JTextComponent;
 
+import cuchaz.enigma.gui.util.ScaleUtil;
+
 public class BoxHighlightPainter implements Highlighter.HighlightPainter {
 	private Color fillColor;
 	private Color borderColor;
@@ -41,10 +43,10 @@ public class BoxHighlightPainter implements Highlighter.HighlightPainter {
 			Rectangle bounds = startRect.union(endRect);
 
 			// adjust the box so it looks nice
-			bounds.x -= 2;
-			bounds.width += 2;
-			bounds.y += 1;
-			bounds.height -= 2;
+			bounds.x -= ScaleUtil.scale(2);
+			bounds.width += ScaleUtil.scale(2);
+			bounds.y += ScaleUtil.scale(1);
+			bounds.height -= ScaleUtil.scale(2);
 
 			return bounds;
 		} catch (BadLocationException ex) {
@@ -56,15 +58,16 @@ public class BoxHighlightPainter implements Highlighter.HighlightPainter {
 	@Override
 	public void paint(Graphics g, int start, int end, Shape shape, JTextComponent text) {
 		Rectangle bounds = getBounds(text, start, end);
+		int arcSize = ScaleUtil.scale(4);
 
 		// fill the area
 		if (this.fillColor != null) {
 			g.setColor(this.fillColor);
-			g.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, 4, 4);
+			g.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arcSize, arcSize);
 		}
 
 		// draw a box around the area
 		g.setColor(this.borderColor);
-		g.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, 4, 4);
+		g.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arcSize, arcSize);
 	}
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/SelectionHighlightPainter.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/SelectionHighlightPainter.java
@@ -21,6 +21,7 @@ import javax.swing.text.Highlighter;
 import javax.swing.text.JTextComponent;
 
 import cuchaz.enigma.gui.config.UiConfig;
+import cuchaz.enigma.gui.util.ScaleUtil;
 
 public class SelectionHighlightPainter implements Highlighter.HighlightPainter {
 	public static final SelectionHighlightPainter INSTANCE = new SelectionHighlightPainter();
@@ -31,7 +32,9 @@ public class SelectionHighlightPainter implements Highlighter.HighlightPainter {
 		Graphics2D g2d = (Graphics2D) g;
 		Rectangle bounds = BoxHighlightPainter.getBounds(text, start, end);
 		g2d.setColor(UiConfig.getSelectionHighlightColor());
-		g2d.setStroke(new BasicStroke(2.0f));
-		g2d.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, 4, 4);
+		g2d.setStroke(new BasicStroke(ScaleUtil.scale(2.0f)));
+
+		int arcSize = ScaleUtil.scale(4);
+		g2d.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arcSize, arcSize);
 	}
 }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
@@ -111,7 +111,6 @@ public class EditorPanel {
 		this.editor.setEditable(false);
 		this.editor.setSelectionColor(new Color(31, 46, 90));
 		this.editor.setCaret(new BrowserCaret());
-		this.editor.setFont(ScaleUtil.getFont(this.editor.getFont().getFontName(), Font.PLAIN, this.fontSize));
 		this.editor.addCaretListener(event -> onCaretMove(event.getDot(), this.mouseIsPressed));
 		this.editor.setCaretColor(UiConfig.getCaretColor());
 		this.editor.setContentType("text/enigma-sources");


### PR DESCRIPTION
- The editor font actually scales now. It didn't before because of multiple reasons:
  - `editor.setFont` was called too early. In this state, the editor doesn't have a font applied, so the system default (non-monospaced!) is returned.
  - This didn't matter though, since `editor.setContentType("text/enigma-sources")` overwrote it anyway with the `DefaultFont` property defined in `EnigmaSyntaxKit` (making the `DEFAULT_FONT` reflection hack redundant, no idea why that existed).
  - `DefaultFont` is usually set to `UiConfig.getFallbackEditorFont()`, which intends to scale the default monospace font to the current DPI settings.
  - This didn't work either though, as `BasicTweaker#modifyFont` only scales `UIResource`s, which `Font` is not a subclass of.
- Highlight boxes are now scaled correctly too.