### PR TITLE
Remove an outer class null check in TranslationClassVisitor

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
@@ -78,9 +78,11 @@ public class TranslationClassVisitor extends ClassVisitor {
 		ClassDefEntry translatedEntry = translator.translate(classEntry);
 		ClassEntry translatedOuterClass = translatedEntry.getOuterClass();
 
-		if (translatedOuterClass == null) {
-			throw new IllegalStateException("Translated inner class did not have outer class");
-		}
+		// JVMS 4.7.6 (java se 20) states that in case an inner class is a top level class, an anonymous class or
+		// a local (nested) class its outer class must be null
+		// if (translatedOuterClass == null) {
+		// 	throw new IllegalStateException("Translated inner class did not have outer class");
+		// }
 
 		// Anonymous classes do not specify an outer or inner name. As we do not translate from the given parameter, ignore if the input is null
 		String translatedName = translatedEntry.getFullName();


### PR DESCRIPTION
According to [JVMS for java SE 20](https://docs.oracle.com/javase/specs/jvms/se20/html/jvms-4.html) there some cases when an inner class shouldn't have an outer one. This check wasn't there until 00fcd05 and the reason for this check isn't provided in code.