### PR TITLE
Clear undo history when updating editor text.

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/EditorPanel.java
@@ -35,6 +35,7 @@ import javax.swing.text.Document;
 import javax.swing.text.Highlighter.HighlightPainter;
 
 import de.sciss.syntaxpane.DefaultSyntaxKit;
+import de.sciss.syntaxpane.SyntaxDocument;
 
 import cuchaz.enigma.EnigmaProject;
 import cuchaz.enigma.analysis.EntryReference;
@@ -503,6 +504,11 @@ public class EditorPanel {
 			this.source = source;
 			this.editor.getHighlighter().removeAllHighlights();
 			this.editor.setText(source.toString());
+
+			// We don't care about the undo/redo history of the syntax pane, any change history would be stored separately
+			if (this.editor.getDocument() instanceof SyntaxDocument syntaxDocument) {
+				syntaxDocument.clearUndos();
+			}
 
 			if (this.source != null) {
 				this.editor.setCaretPosition(newCaretPos);


### PR DESCRIPTION
We don't care about the undo/redo history of the syntax pane, any change history would be stored separately