### PR TITLE
Add temporary bodge to MIO Enigma dir writer to support deltas

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
@@ -78,16 +78,21 @@ public enum MappingFormat {
 		}
 
 		try {
-			if (this == PROGUARD) {
-				mappings = MappingOperations.invert(mappings);
+			if (this == ENIGMA_DIRECTORY) { // TODO: Remove once MIO supports deltas
+				EnigmaMappingsWriter.DIRECTORY.write(mappings, lastUsedMappingIoWriter ? MappingDelta.added(mappings) : delta, path, progressListener, saveParameters, true);
+			} else {
+				if (this == PROGUARD) {
+					mappings = MappingOperations.invert(mappings);
+				}
+
+				VisitableMappingTree tree = MappingIoConverter.toMappingIo(mappings, progressListener);
+				progressListener.init(1, I18n.translate("progress.mappings.writing"));
+				progressListener.step(1, null); // Reset message
+
+				tree.accept(MappingWriter.create(path, mappingIoCounterpart), VisitOrder.createByName());
+				progressListener.step(1, I18n.translate("progress.done"));
 			}
 
-			VisitableMappingTree tree = MappingIoConverter.toMappingIo(mappings, progressListener);
-			progressListener.init(1, I18n.translate("progress.mappings.writing"));
-			progressListener.step(1, null); // Reset message
-
-			tree.accept(MappingWriter.create(path, mappingIoCounterpart), VisitOrder.createByName());
-			progressListener.step(1, I18n.translate("progress.done"));
 			lastUsedMappingIoWriter = true;
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);


### PR DESCRIPTION
MIO's `EnigmaDirWriter` doesn't support writing deltas only, so it deletes the parent directory and rewrites all the mapping files on every save, which is very slow. This PR delegates writes to Enigma's old dir writer, but using MIO's `EnigmaFileWriter` under the hood.

Long-term we need to add native diff handling to MIO.