### PR TITLE
Update to Mapping-IO 0.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ subprojects {
 	dependencies {
 		implementation 'com.google.guava:guava:32.1.2-jre'
 		implementation 'com.google.code.gson:gson:2.10.1'
-		implementation 'net.fabricmc:mapping-io:0.6.1'
+		implementation 'net.fabricmc:mapping-io:0.7.1'
 		
 		compileOnly 'org.jetbrains:annotations:24.0.1'
 

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingFormat.java
@@ -47,7 +47,8 @@ public enum MappingFormat {
 	TSRG_2_FILE(null, null, FileType.TSRG, net.fabricmc.mappingio.format.MappingFormat.TSRG_2_FILE),
 	PROGUARD(null, ProguardMappingsReader.INSTANCE, FileType.TXT, net.fabricmc.mappingio.format.MappingFormat.PROGUARD_FILE),
 	RECAF(RecafMappingsWriter.INSTANCE, RecafMappingsReader.INSTANCE, FileType.TXT, net.fabricmc.mappingio.format.MappingFormat.RECAF_SIMPLE_FILE),
-	JOBF_FILE(null, null, FileType.JOBF, net.fabricmc.mappingio.format.MappingFormat.JOBF_FILE);
+	JOBF_FILE(null, null, FileType.JOBF, net.fabricmc.mappingio.format.MappingFormat.JOBF_FILE),
+	INTELLIJ_MIGRATION_MAP_FILE(null, null, FileType.XML, net.fabricmc.mappingio.format.MappingFormat.INTELLIJ_MIGRATION_MAP_FILE);
 
 	private final MappingsWriter writer;
 	private final MappingsReader reader;
@@ -209,6 +210,7 @@ public enum MappingFormat {
 		public static final FileType TSRG = new FileType(".tsrg");
 		public static final FileType TXT = new FileType(".txt");
 		public static final FileType JOBF = new FileType(".jobf");
+		public static final FileType XML = new FileType(".xml");
 
 		public FileType(String... extensions) {
 			this(List.of(extensions));

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -15,6 +15,7 @@
 	"mapping_format.proguard": "ProGuard File",
 	"mapping_format.recaf": "Recaf Simple File",
 	"mapping_format.jobf_file": "JOBF File",
+	"mapping_format.intellij_migration_map_file": "IntelliJ Migration Map File",
 	"legacy": "legacy",
 
 	"type.methods": "Methods",


### PR DESCRIPTION
Adds support for IntelliJ migration maps.