### PR TITLE
Support multiple input jars

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -147,6 +147,7 @@ public class Gui {
 
 	private void setupUi() {
 		this.jarFileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+		this.jarFileChooser.setMultiSelectionEnabled(true);
 
 		this.exportSourceFileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 		this.exportSourceFileChooser.setAcceptAllFileFilterUsed(false);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -253,13 +253,11 @@ public class GuiController implements ClientPacketHandler {
 		MappingFormat loadedMappingFormat = this.loadedMappingFormat;
 		Path loadedMappingPath = this.loadedMappingPath;
 
-		if (jarPaths != null) { // TODO (Multi-jar): when would this ever be null?
-			this.closeJar();
-			CompletableFuture<Void> f = this.openJar(jarPaths);
+		this.closeJar();
+		CompletableFuture<Void> f = this.openJar(jarPaths);
 
-			if (loadedMappingFormat != null && loadedMappingPath != null) {
-				f.whenComplete((v, t) -> this.openMappings(loadedMappingFormat, loadedMappingPath));
-			}
+		if (loadedMappingFormat != null && loadedMappingPath != null) {
+			f.whenComplete((v, t) -> this.openMappings(loadedMappingFormat, loadedMappingPath));
 		}
 	}
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
@@ -38,7 +38,7 @@ public class Main {
 	public static void main(String[] args) throws IOException {
 		OptionParser parser = new OptionParser();
 
-		OptionSpec<Path> jar = parser.accepts("jar", "Jar file to open at startup").withRequiredArg().withValuesConvertedBy(PathConverter.INSTANCE);
+		OptionSpec<Path> jar = parser.accepts("jar", "Jar file to open at startup; if there are multiple jars, the order must be the same between all collab session members").withRequiredArg().withValuesConvertedBy(PathConverter.INSTANCE);
 
 		OptionSpec<Path> mappings = parser.accepts("mappings", "Mappings file to open at startup").withRequiredArg().withValuesConvertedBy(PathConverter.INSTANCE);
 
@@ -137,8 +137,8 @@ public class Main {
 			}
 
 			if (options.has(jar)) {
-				Path jarPath = options.valueOf(jar);
-				controller.openJar(jarPath).whenComplete((v, t) -> {
+				List<Path> jarPaths = options.valuesOf(jar);
+				controller.openJar(jarPaths).whenComplete((v, t) -> {
 					if (options.has(mappings)) {
 						Path mappingsPath = options.valueOf(mappings);
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
@@ -226,7 +226,6 @@ public class MenuBar {
 		this.githubItem.setText(I18n.translate("menu.help.github"));
 	}
 
-	// TODO (Multi-jar): test that this works
 	private void onOpenJarClicked() {
 		JFileChooser d = this.gui.jarFileChooser;
 		d.setCurrentDirectory(new File(UiConfig.getLastSelectedDir()));

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -225,6 +226,7 @@ public class MenuBar {
 		this.githubItem.setText(I18n.translate("menu.help.github"));
 	}
 
+	// TODO (Multi-jar): test that this works
 	private void onOpenJarClicked() {
 		JFileChooser d = this.gui.jarFileChooser;
 		d.setCurrentDirectory(new File(UiConfig.getLastSelectedDir()));
@@ -235,15 +237,15 @@ public class MenuBar {
 			return;
 		}
 
-		File file = d.getSelectedFile();
+		File[] files = d.getSelectedFiles();
 
 		// checks if the file name is not empty
-		if (file != null) {
-			Path path = file.toPath();
+		if (files.length >= 1) {
+			List<Path> paths = Arrays.stream(files).map(File::toPath).toList();
 
 			// checks if the file name corresponds to an existing file
-			if (Files.exists(path)) {
-				this.gui.getController().openJar(path);
+			if (paths.stream().allMatch(Files::exists)) {
+				this.gui.getController().openJar(paths);
 			}
 
 			UiConfig.setLastSelectedDir(d.getCurrentDirectory().getAbsolutePath());

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -48,17 +48,17 @@ import cuchaz.enigma.utils.I18n;
 public class EnigmaProject {
 	private final Enigma enigma;
 
-	private final Path jarPath;
+	private final List<Path> jarPaths;
 	private final ClassProvider classProvider;
 	private final JarIndex jarIndex;
 	private final byte[] jarChecksum;
 
 	private EntryRemapper mapper;
 
-	public EnigmaProject(Enigma enigma, Path jarPath, ClassProvider classProvider, JarIndex jarIndex, byte[] jarChecksum) {
+	public EnigmaProject(Enigma enigma, List<Path> jarPaths, ClassProvider classProvider, JarIndex jarIndex, byte[] jarChecksum) {
 		Preconditions.checkArgument(jarChecksum.length == 20);
 		this.enigma = enigma;
-		this.jarPath = jarPath;
+		this.jarPaths = List.copyOf(jarPaths);
 		this.classProvider = classProvider;
 		this.jarIndex = jarIndex;
 		this.jarChecksum = jarChecksum;
@@ -78,8 +78,8 @@ public class EnigmaProject {
 		return enigma;
 	}
 
-	public Path getJarPath() {
-		return jarPath;
+	public List<Path> getJarPaths() {
+		return jarPaths;
 	}
 
 	public ClassProvider getClassProvider() {

--- a/enigma/src/main/java/cuchaz/enigma/utils/Utils.java
+++ b/enigma/src/main/java/cuchaz/enigma/utils/Utils.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import com.google.common.base.Preconditions;
 import com.google.common.io.CharStreams;
 
 public class Utils {
@@ -53,7 +54,8 @@ public class Utils {
 		}
 	}
 
-	public static byte[] zipSha1(Path path) throws IOException {
+	public static byte[] zipSha1(Path... paths) throws IOException {
+		Preconditions.checkArgument(paths.length >= 1, "Must provide at least one zip");
 		MessageDigest digest;
 
 		try {
@@ -63,6 +65,14 @@ public class Utils {
 			throw new RuntimeException(e);
 		}
 
+		for (Path path : paths) {
+			appendZipSha1(digest, path);
+		}
+
+		return digest.digest();
+	}
+
+	private static void appendZipSha1(MessageDigest digest, Path path) throws IOException {
 		try (ZipFile zip = new ZipFile(path.toFile())) {
 			List<? extends ZipEntry> entries = Collections.list(zip.entries());
 			// only compare classes (some implementations may not generate directory entries)
@@ -83,8 +93,6 @@ public class Utils {
 				}
 			}
 		}
-
-		return digest.digest();
 	}
 
 	public static void withLock(Lock l, Runnable op) {


### PR DESCRIPTION
This is needed for FabricMC/fabric-loom#1354.

Note for collab sessions: multiple jars should specified in the enigma-swing CLI to set the exact order. The Swing file picker always chooses them in alphabetical order, which may not match what the server has. (Alternatively, the server should specify them in alphabetical order 🙂)

TODO:
- [x] ~~Are there API compat concerns?~~ No
- [x] Resolve all TODOs in code
- [x] Test the reload jar functionality
- [x] Test opening 0/1/2+ jars in the gui
- [x] Test that the jar arg is still required