### PR TITLE
Fix locale-dependent letter case conversions

### DIFF
--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
@@ -56,7 +57,7 @@ public abstract class Command {
 
 	protected static EntryTree<EntryMapping> readMappings(Path path, ProgressListener progress, MappingSaveParameters saveParameters) throws IOException, MappingParseException {
 		// Legacy
-		if (path.getFileName().toString().toLowerCase().endsWith(".zip")) {
+		if (path.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".zip")) {
 			return MappingFormat.ENIGMA_ZIP.read(path, progress, saveParameters, null);
 		}
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 
 import net.fabricmc.mappingio.MappingWriter;
 import net.fabricmc.mappingio.tree.VisitableMappingTree;
@@ -34,7 +35,7 @@ public final class MappingCommandsUtil {
 		MappingFormat format = null;
 
 		try {
-			format = MappingFormat.valueOf(type.toUpperCase());
+			format = MappingFormat.valueOf(type.toUpperCase(Locale.ROOT));
 		} catch (IllegalArgumentException ignored) {
 			if (type.equals("tinyv2")) {
 				format = MappingFormat.TINY_V2;
@@ -101,7 +102,7 @@ public final class MappingCommandsUtil {
 		MappingFormat format = null;
 
 		try {
-			format = MappingFormat.valueOf(type.toUpperCase());
+			format = MappingFormat.valueOf(type.toUpperCase(Locale.ROOT));
 		} catch (IllegalArgumentException ignored) {
 			// ignored
 		}

--- a/enigma-server/src/main/java/cuchaz/enigma/network/DedicatedEnigmaServer.java
+++ b/enigma-server/src/main/java/cuchaz/enigma/network/DedicatedEnigmaServer.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -102,7 +103,7 @@ public class DedicatedEnigmaServer extends EnigmaServer {
 
 				if (Files.isDirectory(mappingsFile)) {
 					mappingFormat = MappingFormat.ENIGMA_DIRECTORY;
-				} else if (mappingsFile.getFileName().toString().toLowerCase().endsWith(".zip")) {
+				} else if (mappingsFile.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".zip")) {
 					mappingFormat = MappingFormat.ENIGMA_ZIP;
 				} else {
 					mappingFormat = MappingFormat.ENIGMA_FILE;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import joptsimple.OptionException;
@@ -143,7 +144,7 @@ public class Main {
 
 						if (Files.isDirectory(mappingsPath)) {
 							controller.openMappings(MappingFormat.ENIGMA_DIRECTORY, mappingsPath);
-						} else if (mappingsPath.getFileName().toString().toLowerCase().endsWith(".zip")) {
+						} else if (mappingsPath.getFileName().toString().toLowerCase(Locale.ROOT).endsWith(".zip")) {
 							controller.openMappings(MappingFormat.ENIGMA_ZIP, mappingsPath);
 						} else {
 							controller.openMappings(MappingFormat.ENIGMA_FILE, mappingsPath);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/config/legacy/Config.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/config/legacy/Config.java
@@ -5,6 +5,7 @@ import java.io.BufferedReader;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -98,7 +99,7 @@ public class Config {
 	private static class IntSerializer implements JsonSerializer<Integer> {
 		@Override
 		public JsonElement serialize(Integer src, Type typeOfSrc, JsonSerializationContext context) {
-			return new JsonPrimitive("#" + Integer.toHexString(src).toUpperCase());
+			return new JsonPrimitive("#" + Integer.toHexString(src).toUpperCase(Locale.ROOT));
 		}
 	}
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -17,6 +17,7 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.util.Locale;
 import java.util.Objects;
 
 import javax.swing.JButton;
@@ -223,7 +224,7 @@ public class JavadocDialog {
 		}
 
 		public String getText() {
-			return "@" + this.name().toLowerCase();
+			return "@" + this.name().toLowerCase(Locale.ROOT);
 		}
 
 		public boolean isInline() {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/util/ScaleUtil.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/util/ScaleUtil.java
@@ -5,6 +5,7 @@ import java.awt.Font;
 import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Predicate;
 
 import javax.swing.BorderFactory;
@@ -98,7 +99,7 @@ public class ScaleUtil {
 
 	@SuppressWarnings("null")
 	private static BasicTweaker createTweakerForCurrentLook(float dpiScaling) {
-		String testString = UIManager.getLookAndFeel().getName().toLowerCase();
+		String testString = UIManager.getLookAndFeel().getName().toLowerCase(Locale.ROOT);
 
 		if (testString.contains("windows")) {
 			return new WindowsTweaker(dpiScaling, testString.contains("classic")) {

--- a/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
@@ -3,6 +3,7 @@ package cuchaz.enigma.analysis;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -67,9 +68,9 @@ public class StructureTreeNode extends DefaultMutableTreeNode {
 		case DEFAULT -> children;
 		case A_Z -> children.sorted(Comparator.comparing(e -> (e instanceof MethodEntry m && m.isConstructor())
 																// compare the class name when the entry is a constructor
-																? project.getMapper().deobfuscate(e.getParent()).getSimpleName().toLowerCase() : project.getMapper().deobfuscate(e).getSimpleName().toLowerCase()));
+																? project.getMapper().deobfuscate(e.getParent()).getSimpleName().toLowerCase(Locale.ROOT) : project.getMapper().deobfuscate(e).getSimpleName().toLowerCase()));
 		case Z_A -> children.sorted(
-				Comparator.comparing(e -> (e instanceof MethodEntry m && m.isConstructor()) ? project.getMapper().deobfuscate(((ParentedEntry<?>) e).getParent()).getSimpleName().toLowerCase() : project.getMapper().deobfuscate((ParentedEntry<?>) e).getSimpleName().toLowerCase()).reversed());
+				Comparator.comparing(e -> (e instanceof MethodEntry m && m.isConstructor()) ? project.getMapper().deobfuscate(((ParentedEntry<?>) e).getParent()).getSimpleName().toLowerCase() : project.getMapper().deobfuscate((ParentedEntry<?>) e).getSimpleName().toLowerCase(Locale.ROOT)).reversed());
 		};
 
 		for (ParentedEntry<?> child : children.toList()) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/AccessFlags.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/AccessFlags.java
@@ -1,6 +1,7 @@
 package cuchaz.enigma.translation.representation;
 
 import java.lang.reflect.Modifier;
+import java.util.Locale;
 
 import org.objectweb.asm.Opcodes;
 
@@ -110,7 +111,7 @@ public class AccessFlags {
 
 	@Override
 	public String toString() {
-		StringBuilder builder = new StringBuilder(Access.get(this).toString().toLowerCase());
+		StringBuilder builder = new StringBuilder(Access.get(this).toString().toLowerCase(Locale.ROOT));
 
 		if (isStatic()) {
 			builder.append(" static");


### PR DESCRIPTION
`toUpperCase` and `toLowerCase` specify `Locale.ROOT` everywhere now. I think there were existing strings that would cause issues on Turkish computers in `ScaleUtil` and the `.zip` extension checks.