### PR TITLE
Fix crash from multimap conversion

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
@@ -43,7 +43,7 @@ public class StructureTreeNode extends DefaultMutableTreeNode {
 	}
 
 	public void load(EnigmaProject project, StructureTreeOptions options) {
-		Stream<ParentedEntry<?>> children = project.getJarIndex().getChildrenByClass().get(this.parentEntry).stream();
+		Stream<ParentedEntry<?>> children = project.getJarIndex().getChildrenByClass().getOrDefault(this.parentEntry, List.of()).stream();
 
 		children = switch (options.obfuscationVisibility()) {
 		case ALL -> children;


### PR DESCRIPTION
When multithreading indexing, I converted some guava multimaps to regular maps. This means that `get` can now return null rather than an empty list. I thought I got all the spots that needed changing but it seems I missed one.