### PR TITLE
Fix decompiler input transformer service

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -306,10 +306,12 @@ public class EnigmaProject implements ProjectView {
 		public Stream<ClassSource> decompileStream(EnigmaProject project, ProgressListener progress, DecompilerService decompilerService, DecompileErrorStrategy errorStrategy) {
 			Collection<ClassNode> classes = this.compiled.values().stream()
 					.filter(classNode -> classNode.name.indexOf('$') == -1)
-					.peek(classNode -> {
+					.map(classNode -> {
 						for (DecompilerInputTransformerService transformer : project.enigma.getServices().get(DecompilerInputTransformerService.TYPE)) {
-							transformer.transform(classNode);
+							classNode = transformer.transform(classNode);
 						}
+
+						return classNode;
 					})
 					.toList();
 

--- a/enigma/src/main/java/cuchaz/enigma/api/service/DecompilerInputTransformerService.java
+++ b/enigma/src/main/java/cuchaz/enigma/api/service/DecompilerInputTransformerService.java
@@ -5,5 +5,5 @@ import org.objectweb.asm.tree.ClassNode;
 public interface DecompilerInputTransformerService extends EnigmaService {
 	EnigmaServiceType<DecompilerInputTransformerService> TYPE = EnigmaServiceType.create("decompiler_input_transformer");
 
-	void transform(ClassNode classNode);
+	ClassNode transform(ClassNode classNode);
 }

--- a/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
@@ -23,7 +23,6 @@ import javax.swing.SwingUtilities;
 import org.jetbrains.annotations.Nullable;
 
 import cuchaz.enigma.EnigmaProject;
-import cuchaz.enigma.classprovider.CachingClassProvider;
 import cuchaz.enigma.classprovider.DecompilerInputTransformingClassProvider;
 import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
 import cuchaz.enigma.events.ClassHandleListener;
@@ -106,9 +105,9 @@ public final class ClassHandleProvider {
 
 	private Decompiler createDecompiler() {
 		return ds.create(
-				new DecompilerInputTransformingClassProvider(
-						new CachingClassProvider(new ObfuscationFixClassProvider(project.getClassProvider(), project.getJarIndex())),
-						project.getEnigma().getServices()
+				new ObfuscationFixClassProvider(
+						new DecompilerInputTransformingClassProvider(project.getClassProvider(), project.getEnigma().getServices()),
+						project.getJarIndex()
 				),
 				new SourceSettings(true, true)
 		);

--- a/enigma/src/main/java/cuchaz/enigma/classprovider/DecompilerInputTransformingClassProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classprovider/DecompilerInputTransformingClassProvider.java
@@ -31,13 +31,10 @@ public class DecompilerInputTransformingClassProvider implements ClassProvider {
 			return null;
 		}
 
-		// copy the class, so that the input class isn't modified (which could lead to the class being retransformed if
-		// it's cached)
-		ClassNode classCopy = new ClassNode();
-		classNode.accept(classCopy);
+		for (DecompilerInputTransformerService transformer : services.get(DecompilerInputTransformerService.TYPE)) {
+			classNode = transformer.transform(classNode);
+		}
 
-		services.get(DecompilerInputTransformerService.TYPE).forEach(transformer -> transformer.transform(classCopy));
-
-		return classCopy;
+		return classNode;
 	}
 }


### PR DESCRIPTION
There are two fixes here
- `DecompilerInputTransformerServices` is now expected to return a new `ClassNode` rather than transforming it in-place. This matches more class transforming APIs.
- `ObfuscationFixClassProvider` is now applied *after* the decompiler input transformers, to avoid running them on different input classes than vanilla and confusing them. This unfortunately means the caching here is gone, but it's not a hot path so I don't think it matters in practice. Caching the output of `DecompilerInputTransformerService` isn't valid unless that cache is invalidated when the plugin requests a new decompile, and I didn't feel like handling that for now. The class provider itself already has a layer of caching