### PR TITLE
Move to next token when using the tabulator

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/events/ConvertingTextFieldListener.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/events/ConvertingTextFieldListener.java
@@ -3,13 +3,19 @@ package cuchaz.enigma.gui.events;
 import cuchaz.enigma.gui.elements.ConvertingTextField;
 
 public interface ConvertingTextFieldListener {
+	enum StopEditingCause {
+		ABORT,
+		DO,
+		TAB
+	}
+
 	default void onStartEditing(ConvertingTextField field) {
 	}
 
-	default boolean tryStopEditing(ConvertingTextField field, boolean abort) {
+	default boolean tryStopEditing(ConvertingTextField field, StopEditingCause cause) {
 		return true;
 	}
 
-	default void onStopEditing(ConvertingTextField field, boolean abort) {
+	default void onStopEditing(ConvertingTextField field, StopEditingCause cause) {
 	}
 }


### PR DESCRIPTION
It's a bit finicky to use as it doesn't grab focus by default (i.e. tabbing whilst not editing should still mostly be old behaviour), and tabbing twice to skip a isn't a thing either. Although both issues are more or less connected to each other.

Resolving the loss of focus on tabbing issue probably requires a small refractor in `IdentifierPanel#refreshReference` to not throw out the old `ConvertingTextField` instance. However, that is conjecture on my side, the actual fix might be more involved or simplier - although I personally haven't managed to find a clear-cut approach beyond this lead after two hours of trying.

This PR also introduces a slight visual bug where when the user maps tokens in a short amount of time, so highlight painters will highlight the wrong sections of text. However, as the root source is not exactly related to this PR and resolving it would be a bit more involved I decided to not include such a change in this PR for now. I may try to resolve it if requested though (though for a small visual glitch that resolves itself after a second of waiting resolving it might be a bit overkill anyways)

Closes #113 