### PR TITLE
Fix class version check in AddFramesIfNecessaryClassProvider

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/classprovider/AddFramesIfNecessaryClassProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classprovider/AddFramesIfNecessaryClassProvider.java
@@ -34,7 +34,7 @@ public class AddFramesIfNecessaryClassProvider implements ClassProvider {
 			return null;
 		}
 
-		if (clazz.version >= Opcodes.V1_7) {
+		if ((clazz.version & 0xffff) >= Opcodes.V1_7) {
 			// already has frames
 			return clazz;
 		}


### PR DESCRIPTION
The minor class version is stored in the upper 16 bits of `ClassNode.version`, causing this check to fail for class version 45.3 (JDK 1.0.2). This would lead to classes not having frames inserted into them, which causes subsequent problems down the line for analysis that requires frames.

Closes #570 