### PR TITLE
Fix writing enigma mappings directories

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProfile.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProfile.java
@@ -48,6 +48,10 @@ public final class EnigmaProfile {
 	}
 
 	public MappingSaveParameters getMappingSaveParameters() {
-		return mappingSaveParameters;
+		if (mappingSaveParameters == null) {
+			return DEFAULT_MAPPING_SAVE_PARAMETERS;
+		} else {
+			return mappingSaveParameters;
+		}
 	}
 }


### PR DESCRIPTION
See #572 

---

The reproduction steps is basically exporting the mappings as an enigma directory (without an enigma profile being read from disk).

I've checked whether `getDisabledPlugins()` also has incorrect default values from gson, but that's not the case. Why the two differ is a bit outside my realm of expertise when it comes to using gson (these kinds of issues are the reason I prefer doing my json serde mostly manually).